### PR TITLE
feat: add support for 'extra buttons' on date components

### DIFF
--- a/src/components/date/index.njk
+++ b/src/components/date/index.njk
@@ -84,6 +84,21 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
+                {% if extraActionButtons|length %}
+                    {% for extraActionButton in extraActionButtons %}
+                        {{ govukButton({
+                            text: extraActionButton.text,
+                            type: extraActionButton.type,
+                            href: extraActionButton.href,
+                            attributes: {
+                                "formaction": extraActionButton.formaction or "",
+                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
+                                "name": extraActionButton.text|lower|replace(" ", "-")
+                            },
+                            classes: extraActionButton.classes or "govuk-button--secondary"
+                        }) }}
+                    {% endfor %}
+                {% endif %}
             </form>
         </div>
     </div>


### PR DESCRIPTION
Pulling the change from https://github.com/Planning-Inspectorate/crown-developments/commit/89488d32bb52d2ffd4b82dac03650a5b4d18b563

Future task to make this more of a documented feature and potentially apply to all components