### PR TITLE
Feat(multi-input-field): allow users to add prefix and suffix to input fields

### DIFF
--- a/src/components/multi-field-input/index.njk
+++ b/src/components/multi-field-input/index.njk
@@ -60,11 +60,13 @@
                             errorMessage: errors[inputField.fieldName] and {
                                 text: errors[inputField.fieldName].msg
                             },
+                            prefix: inputField.prefix,
+                            suffix: inputField.suffix,
                             value: inputField.value,
                             hint: {
                                 text: inputField.hint
                             },
-                            classes: "govuk-input-!-width-three-quarters",
+                            classes: inputField.classes or "govuk-input-!-width-three-quarters",
                             attributes: inputField.attributes
                         }) }}
                     {% endfor %}

--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -11,6 +11,12 @@ import { nl2br } from '../../lib/utils.js';
  */
 
 /**
+ * @typedef {Object} Suffix
+ * @property {string} text
+ * @property {string} [classes] optional property, used to add classes to the suffix/prefix
+ */
+
+/**
  * @typedef {Object} InputField
  * @property {string} fieldName
  * @property {string} label
@@ -18,6 +24,8 @@ import { nl2br } from '../../lib/utils.js';
  * @property {string} [formatPrefix] optional property, used by formatAnswerForSummary (eg task list display), to prefix answer
  * @property {function} [formatTextFunction] optional property, used to format the answer for display and value in question
  * @property {Record<string, string>} [attributes] optional property, used to add html attributes to the field
+ * @property {Suffix} [suffix] optional property, used to add a suffix to the field
+ * @property {Suffix} [prefix] optional property, used to add a prefix to the field
  */
 
 /**


### PR DESCRIPTION
Users can now add prefix and suffix as describe here: https://design-system.service.gov.uk/components/text-input/#options-example-of-an-input-asking-for-numbers-with-decimal-places-text-input-example--prefix