### PR TITLE
feat: allow redacted text entry summary to be truncated if required

### DIFF
--- a/src/components/text-entry-redact/question.js
+++ b/src/components/text-entry-redact/question.js
@@ -82,7 +82,6 @@ export default class TextEntryRedactQuestion extends Question {
 
 	formatAnswerForSummary(sectionSegment, journey, answer, capitals = true) {
 		const redacted = journey.response.answers[this.fieldName + 'Redacted'];
-		const action = this.getAction(sectionSegment, journey, answer);
 		let toShow;
 		if (this.onlyShowRedactedValueForSummary) {
 			toShow = redacted;
@@ -91,6 +90,7 @@ export default class TextEntryRedactQuestion extends Question {
 		}
 
 		if (this.shouldTruncateSummary && toShow?.length > TRUNCATED_MAX_LENGTH) {
+			const action = this.getAction(sectionSegment, journey, answer);
 			const truncatedToShow = toShow.substring(0, TRUNCATED_MAX_LENGTH);
 			toShow = `${truncatedToShow}... <a class="govuk-link govuk-link--no-visited-state" href="${action?.href}">Read more</a>`;
 			return [

--- a/src/components/text-entry-redact/question.js
+++ b/src/components/text-entry-redact/question.js
@@ -80,7 +80,7 @@ export default class TextEntryRedactQuestion extends Question {
 		return viewModel;
 	}
 
-	formatAnswerForSummary(sectionSegment, journey, answer) {
+	formatAnswerForSummary(sectionSegment, journey, answer, capitals = true) {
 		const redacted = journey.response.answers[this.fieldName + 'Redacted'];
 		const action = this.getAction(sectionSegment, journey, answer);
 		let toShow;
@@ -93,14 +93,15 @@ export default class TextEntryRedactQuestion extends Question {
 		if (this.shouldTruncateSummary && toShow?.length > TRUNCATED_MAX_LENGTH) {
 			const truncatedToShow = toShow.substring(0, TRUNCATED_MAX_LENGTH);
 			toShow = `${truncatedToShow}... <a class="govuk-link govuk-link--no-visited-state" href="${action?.href}">Read more</a>`;
+			return [
+				{
+					key: this.title ?? this.question,
+					value: nl2br(toShow),
+					action
+				}
+			];
 		}
 
-		return [
-			{
-				key: this.title ?? this.question,
-				value: nl2br(toShow),
-				action
-			}
-		];
+		return super.formatAnswerForSummary(sectionSegment, journey, toShow, capitals);
 	}
 }

--- a/src/components/text-entry-redact/question.test.js
+++ b/src/components/text-entry-redact/question.test.js
@@ -159,4 +159,113 @@ describe('./src/dynamic-forms/components/text-entry-redact/question.js', () => {
 		assert.match(view, /Redaction suggestions/);
 		assert.match(view, /We have suggested some common redactions/);
 	});
+	it('should format answer for summary', () => {
+		const question = createQuestion();
+		const journey = {
+			baseUrl: '',
+			taskListUrl: 'task',
+			journeyTemplate: 'template',
+			journeyTitle: 'title',
+			journeyId: 'manage-representations',
+			getBackLink: () => {
+				return 'back';
+			},
+			getCurrentQuestionUrl: () => {
+				return '/redacted-comment';
+			},
+			response: {
+				answers: {}
+			}
+		};
+		const answer =
+			'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. ████████ ██████ adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; ████████ wrote in his notebook, letting the day delay his errands, wholly unhurried and serene.';
+
+		const viewModel = question.formatAnswerForSummary('section', journey, answer);
+
+		assert.deepStrictEqual(viewModel, [
+			{
+				key: 'title',
+				value:
+					'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. ████████ ██████ adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; ████████ wrote in his notebook, letting the day delay his errands, wholly unhurried and serene.',
+				action: {
+					href: '/redacted-comment',
+					text: 'Change',
+					visuallyHiddenText: 'Question?'
+				}
+			}
+		]);
+	});
+	it('should truncate when formating answer for summary when shouldTruncateSummary is true', () => {
+		const question = createQuestion();
+		question.shouldTruncateSummary = true;
+		const journey = {
+			baseUrl: '',
+			taskListUrl: 'task',
+			journeyTemplate: 'template',
+			journeyTitle: 'title',
+			journeyId: 'manage-representations',
+			getBackLink: () => {
+				return 'back';
+			},
+			getCurrentQuestionUrl: () => {
+				return '/redacted-comment';
+			},
+			response: {
+				answers: {}
+			}
+		};
+		const answer =
+			'It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. ████████ ██████ adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; ████████ wrote in his notebook, letting the day delay his errands, wholly unhurried and serene.';
+
+		const viewModel = question.formatAnswerForSummary('section', journey, answer);
+
+		assert.deepStrictEqual(viewModel, [
+			{
+				key: 'title',
+				value: `It began with an ordinary morning. The air smelled faintly of dew, the street empty but for leaves drifting lazily. ████████ ██████ adjusted his collar, noting his watch was three minutes late—a stubborn old thing, loyal only to its own time. Across the street, a bakery opened, the scent of bread spilling into the cool air. A woman in a green scarf carried loaves in quiet balance. The square stirred slowly; ████████ wrote in his notebook, letting the day delay his errands, wholly unhurried and s... <a class="govuk-link govuk-link--no-visited-state" href="/redacted-comment">Read more</a>`,
+				action: {
+					href: '/redacted-comment',
+					text: 'Change',
+					visuallyHiddenText: 'Question?'
+				}
+			}
+		]);
+	});
+	it('should not truncate when formating answer for summary when shouldTruncateSummary is true and length less than 500', () => {
+		const question = createQuestion();
+		question.shouldTruncateSummary = true;
+		const journey = {
+			baseUrl: '',
+			taskListUrl: 'task',
+			journeyTemplate: 'template',
+			journeyTitle: 'title',
+			journeyId: 'manage-representations',
+			getBackLink: () => {
+				return 'back';
+			},
+			getCurrentQuestionUrl: () => {
+				return '/redacted-comment';
+			},
+			response: {
+				answers: {}
+			}
+		};
+		const answer =
+			'It began, as many stories do, with an ordinary morning. The air carried the faint smell of dew, and the street was empty save for a few scattered leaves drifting lazily o████████ze too shy to commit to being wind. Jonathan Price adjusted his collar and glanced at his watch, noting with mild irritation tha███████████████████████████ree minutes late.';
+
+		const viewModel = question.formatAnswerForSummary('section', journey, answer);
+
+		assert.deepStrictEqual(viewModel, [
+			{
+				key: 'title',
+				value:
+					'It began, as many stories do, with an ordinary morning. The air carried the faint smell of dew, and the street was empty save for a few scattered leaves drifting lazily o████████ze too shy to commit to being wind. Jonathan Price adjusted his collar and glanced at his watch, noting with mild irritation tha███████████████████████████ree minutes late.',
+				action: {
+					href: '/redacted-comment',
+					text: 'Change',
+					visuallyHiddenText: 'Question?'
+				}
+			}
+		]);
+	});
 });


### PR DESCRIPTION
<img width="1079" height="478" alt="Screenshot 2025-08-13 at 13 46 38" src="https://github.com/user-attachments/assets/c7b2e8ee-b5d5-4ed7-9d08-05bea21a410b" />
