### PR TITLE
fix: trim error on remove paths

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -246,9 +246,16 @@ export function buildSave(saveData, redirectToTaskListOnSuccess) {
 				return question.renderAction(res, errorViewModel);
 			}
 
-			// save
-			const data = await question.getDataToSave(req, journeyResponse);
+			let data;
 
+			if (req.path.endsWith('/remove')) {
+				// For remove operations, we just need the field names - skip question-specific validation
+				data = { answers: { [question.fieldName]: null } };
+			} else {
+				data = await question.getDataToSave(req, journeyResponse);
+			}
+
+			// save
 			await saveData({
 				req,
 				res,


### PR DESCRIPTION
When adding remove functionality that navigates to a /remove route and is used to remove the value of a question - we were getting a TypeError as the `getDataToSave` function tries to trim the field value. As the field no longer has a value - this would result in a .trim error.

The reason for this is that buildSave always calls question.getDataToSave(), which for options-based questions tries to read the submitted form value, trim it, and validate it against the list of allowed options.

But on a remove request, there's no value in the form body — the user isn't submitting an answer, they're deleting one. So getDataToSave tries to call .trim() on undefined, which caused a TypeError.

The fix is to recognise that remove operations don't need to go through the question's validation logic at all. They just need to know which field to clear. So we short-circuit in buildSave — if the request is a remove, we skip getDataToSave entirely and just pass the field name with a null value.

<img width="1284" height="874" alt="image" src="https://github.com/user-attachments/assets/9d1e77fc-fe6d-4e02-9048-5dee1fda1d50" />
