### PR TITLE
feat: add option to disable accessible autocomplete

### DIFF
--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -4,7 +4,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block head %}
-    <link rel="stylesheet" href="/assets/css/accessible-autocomplete.min.css"/>
+    {% if not question.disableAccessibleAutocomplete %}
+        <link rel="stylesheet" href="/assets/css/accessible-autocomplete.min.css"/>
+    {% endif %}
 
     {{ super() }}
 {% endblock %}
@@ -61,22 +63,24 @@
             </form>
         </div>
     </div>
-    <script src="/assets/js/accessible-autocomplete.min.js"></script>
-    <script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
-        if (window.accessibleAutocomplete) {
-            accessibleAutocomplete.enhanceSelectElement({
-                selectElement: document.querySelector('#{{ question.fieldName }}'),
-                onConfirm: () => {
-                    let input = document.querySelector('#{{ question.fieldName }}');
-                    let select = document.querySelector('#{{ question.fieldName }}-select');
-                    let options = Array.from(select.options);
-                    if (!input.value || !options.some(option => option.innerText === input.value)) {
-                        select.options.selectedIndex = -1;
-                    } else {
-                        select.options.selectedIndex = options.findIndex(option => option.innerText === input.value);
+    {% if not question.disableAccessibleAutocomplete %}
+        <script src="/assets/js/accessible-autocomplete.min.js"></script>
+        <script {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>
+            if (window.accessibleAutocomplete) {
+                accessibleAutocomplete.enhanceSelectElement({
+                    selectElement: document.querySelector('#{{ question.fieldName }}'),
+                    onConfirm: () => {
+                        let input = document.querySelector('#{{ question.fieldName }}');
+                        let select = document.querySelector('#{{ question.fieldName }}-select');
+                        let options = Array.from(select.options);
+                        if (!input.value || !options.some(option => option.innerText === input.value)) {
+                            select.options.selectedIndex = -1;
+                        } else {
+                            select.options.selectedIndex = options.findIndex(option => option.innerText === input.value);
+                        }
                     }
-                }
-            })
-        }
-    </script>
+                })
+            }
+        </script>
+    {% endif %}
 {% endblock %}

--- a/src/components/select/question.js
+++ b/src/components/select/question.js
@@ -1,6 +1,7 @@
 import OptionsQuestion from '../../questions/options-question.js';
 
 export default class SelectQuestion extends OptionsQuestion {
+	#disableAccessibleAutocomplete;
 	/**
 	 * @param {Object} params
 	 * @param {string} params.title
@@ -14,6 +15,7 @@ export default class SelectQuestion extends OptionsQuestion {
 	 * @param {string} [params.label]
 	 * @param {string} [params.html]
 	 * @param {string} [params.legend] - optional legend, used instead of h1
+	 * @param {string} [params.disableAccessibleAutocomplete]
 	 * @param {Array.<import('../../questions/options-question.js').Option>} params.options
 	 * @param {Object<string, any>} [params.viewData]
 	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
@@ -30,6 +32,7 @@ export default class SelectQuestion extends OptionsQuestion {
 		label,
 		html,
 		legend,
+		disableAccessibleAutocomplete,
 		options,
 		validators,
 		viewData
@@ -51,6 +54,7 @@ export default class SelectQuestion extends OptionsQuestion {
 		this.html = html;
 		this.label = label;
 		this.legend = legend;
+		this.#disableAccessibleAutocomplete = disableAccessibleAutocomplete;
 	}
 
 	/**
@@ -59,6 +63,7 @@ export default class SelectQuestion extends OptionsQuestion {
 	addCustomDataToViewModel(viewModel) {
 		viewModel.question.label = this.label;
 		viewModel.question.legend = this.legend;
+		viewModel.question.disableAccessibleAutocomplete = this.#disableAccessibleAutocomplete;
 	}
 
 	/**

--- a/src/components/select/question.test.js
+++ b/src/components/select/question.test.js
@@ -1,8 +1,9 @@
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert';
 import ValidOptionValidator from '../../validator/valid-option-validator.js';
 import SelectQuestion from './question.js';
 import nunjucks from 'nunjucks';
+import { configureNunjucksTestEnv } from '#test/utils/nunjucks.js';
 
 const TITLE = 'Select question';
 const QUESTION = 'A select question';
@@ -92,6 +93,81 @@ describe('./src/dynamic-forms/components/select/question.js', () => {
 		const preppedQuestion = selectQuestion.prepQuestionForRendering(SECTION, JOURNEY, customViewData);
 
 		assert.strictEqual(preppedQuestion.question.label, LABEL);
+	});
+
+	it('should pass in disableAccessibleAutocomplete property to view', (ctx) => {
+		nunjucks.render = ctx.mock.fn();
+		nunjucks.render.mock.mockImplementation(() => {});
+
+		const selectQuestion = new SelectQuestion({
+			title: TITLE,
+			question: QUESTION,
+			description: DESCRIPTION,
+			fieldName: FIELDNAME,
+			html: HTML,
+			label: LABEL,
+			options: OPTIONS,
+			disableAccessibleAutocomplete: true
+		});
+
+		const customViewData = { hello: 'hi' };
+
+		const preppedQuestion = selectQuestion.prepQuestionForRendering(SECTION, JOURNEY, customViewData);
+
+		assert.strictEqual(preppedQuestion.question.disableAccessibleAutocomplete, true);
+	});
+
+	it('should include accessible autocomplete by default', async () => {
+		const selectQuestion = new SelectQuestion({
+			title: TITLE,
+			question: QUESTION,
+			description: DESCRIPTION,
+			fieldName: FIELDNAME,
+			html: HTML,
+			label: LABEL,
+			options: OPTIONS
+		});
+		const viewModel = selectQuestion.prepQuestionForRendering(SECTION, JOURNEY, {
+			layoutTemplate: 'views/layout-journey.njk'
+		});
+
+		const nunjucks = configureNunjucksTestEnv();
+		const mockRes = {
+			render: mock.fn((view, data) => nunjucks.render(view + '.njk', data))
+		};
+		selectQuestion.renderAction(mockRes, viewModel);
+
+		assert.strictEqual(mockRes.render.mock.callCount(), 1);
+		const view = mockRes.render.mock.calls[0].result;
+		assert.ok(view);
+		assert.match(view, /accessible-autocomplete\.min\.js/);
+	});
+
+	it('should not include accessible autocomplete if configured', async () => {
+		const selectQuestion = new SelectQuestion({
+			title: TITLE,
+			question: QUESTION,
+			description: DESCRIPTION,
+			fieldName: FIELDNAME,
+			html: HTML,
+			label: LABEL,
+			options: OPTIONS,
+			disableAccessibleAutocomplete: true
+		});
+		const viewModel = selectQuestion.prepQuestionForRendering(SECTION, JOURNEY, {
+			layoutTemplate: 'views/layout-journey.njk'
+		});
+
+		const nunjucks = configureNunjucksTestEnv();
+		const mockRes = {
+			render: mock.fn((view, data) => nunjucks.render(view + '.njk', data))
+		};
+		selectQuestion.renderAction(mockRes, viewModel);
+
+		assert.strictEqual(mockRes.render.mock.callCount(), 1);
+		const view = mockRes.render.mock.calls[0].result;
+		assert.ok(view);
+		assert.doesNotMatch(view, /accessible-autocomplete\.min\.js/);
 	});
 
 	it('should add selected attribute to chosen option', (ctx) => {

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -129,6 +129,7 @@ type RadioQuestionProps = CommonQuestionProps & {
 type SelectQuestionProps = CommonQuestionProps & {
 	type: 'select';
 	options: Option[];
+	disableAccessibleAutocomplete?: boolean;
 };
 
 type SingleLineInputQuestionProps = CommonQuestionProps & {

--- a/test/snapshots/travel-class.html
+++ b/test/snapshots/travel-class.html
@@ -26,21 +26,21 @@
             </form>
         </div>
     </div>
-    <script src="/assets/js/accessible-autocomplete.min.js"></script>
-    <script >
-        if (window.accessibleAutocomplete) {
-            accessibleAutocomplete.enhanceSelectElement({
-                selectElement: document.querySelector('#travelClass'),
-                onConfirm: () => {
-                    let input = document.querySelector('#travelClass');
-                    let select = document.querySelector('#travelClass-select');
-                    let options = Array.from(select.options);
-                    if (!input.value || !options.some(option => option.innerText === input.value)) {
-                        select.options.selectedIndex = -1;
-                    } else {
-                        select.options.selectedIndex = options.findIndex(option => option.innerText === input.value);
+        <script src="/assets/js/accessible-autocomplete.min.js"></script>
+        <script >
+            if (window.accessibleAutocomplete) {
+                accessibleAutocomplete.enhanceSelectElement({
+                    selectElement: document.querySelector('#travelClass'),
+                    onConfirm: () => {
+                        let input = document.querySelector('#travelClass');
+                        let select = document.querySelector('#travelClass-select');
+                        let options = Array.from(select.options);
+                        if (!input.value || !options.some(option => option.innerText === input.value)) {
+                            select.options.selectedIndex = -1;
+                        } else {
+                            select.options.selectedIndex = options.findIndex(option => option.innerText === input.value);
+                        }
                     }
-                }
-            })
-        }
-    </script>
+                })
+            }
+        </script>


### PR DESCRIPTION
Added a new option: `disableAccessibleAutocomplete` to the SELECT component. Backwards compatible as the default behaviour is unchanged.

https://pins-ds.atlassian.net/browse/RDSD-210