### PR TITLE
feat: adds extra action buttons to booleans and date period

### DIFF
--- a/src/components/boolean/index.njk
+++ b/src/components/boolean/index.njk
@@ -60,6 +60,21 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
+                {% if extraActionButtons|length %}
+                    {% for extraActionButton in extraActionButtons %}
+                        {{ govukButton({
+                            text: extraActionButton.text,
+                            type: extraActionButton.type,
+                            href: extraActionButton.href,
+                            attributes: {
+                                "formaction": extraActionButton.formaction or "",
+                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
+                                "name": extraActionButton.text|lower|replace(" ", "-")
+                            },
+                            classes: extraActionButton.classes or "govuk-button--secondary"
+                        }) }}
+                    {% endfor %}
+                {% endif %}
             </form>
         </div>
     </div>

--- a/src/components/boolean/question.js
+++ b/src/components/boolean/question.js
@@ -59,7 +59,8 @@ export default class BooleanQuestion extends RadioQuestion {
 		validators,
 		interfaceType = 'radio',
 		options,
-		editable
+		editable,
+		viewData
 	}) {
 		let defaultOptions = options || [
 			{
@@ -90,7 +91,8 @@ export default class BooleanQuestion extends RadioQuestion {
 			options: defaultOptions,
 			validators,
 			html,
-			editable
+			editable,
+			viewData
 		});
 
 		this.interfaceType = interfaceType;

--- a/src/components/date-period/index.njk
+++ b/src/components/date-period/index.njk
@@ -122,6 +122,21 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
+                {% if extraActionButtons|length %}
+                    {% for extraActionButton in extraActionButtons %}
+                        {{ govukButton({
+                            text: extraActionButton.text,
+                            type: extraActionButton.type,
+                            href: extraActionButton.href,
+                            attributes: {
+                                "formaction": extraActionButton.formaction or "",
+                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
+                                "name": extraActionButton.text|lower|replace(" ", "-")
+                            },
+                            classes: extraActionButton.classes or "govuk-button--secondary"
+                        }) }}
+                    {% endfor %}
+                {% endif %}
             </form>
         </div>
     </div>


### PR DESCRIPTION
- Adds the ability to pass `extraActionButtons` into two new components (1) booleans and (2) date periods.
- This allows for the ability to, for example, add a `Remove` button to these components, allowing users to remove answers

[RDSD-245](https://pins-ds.atlassian.net/browse/RDSD-245)

[RDSD-245]: https://pins-ds.atlassian.net/browse/RDSD-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ