### PR TITLE
fix: make LPACode assignment conditional on defined value

### DIFF
--- a/src/journey/journey-response.js
+++ b/src/journey/journey-response.js
@@ -37,6 +37,8 @@ export class JourneyResponse {
 		} else {
 			this.answers = {};
 		}
-		this.LPACode = lpaCode;
+		if (lpaCode !== undefined) {
+			this.LPACode = lpaCode;
+		}
 	}
 }

--- a/src/journey/journey-response.test.js
+++ b/src/journey/journey-response.test.js
@@ -28,5 +28,18 @@ describe('JourneyResponse class', () => {
 			const response = new JourneyResponse('', '', answers);
 			assert.strictEqual(response.answers, answers);
 		});
+
+		it('should not set LPACode when lpaCode is omitted', () => {
+			const response = new JourneyResponse('journey-1', 'ref-1', { q1: 'yes' });
+			assert.strictEqual(response.LPACode, undefined);
+			assert.strictEqual(Object.hasOwn(response, 'LPACode'), false);
+		});
+
+		it('should set LPACode when lpaCode is provided', () => {
+			const lpaCode = 'LPA-001';
+			const response = new JourneyResponse('journey-1', 'ref-1', { q1: 'yes' }, lpaCode);
+			assert.strictEqual(response.LPACode, lpaCode);
+			assert.strictEqual(Object.hasOwn(response, 'LPACode'), true);
+		});
 	});
 });


### PR DESCRIPTION
`LPACode` is an optional param, not used by some projects, but because it's always assigned it is not marked as an optional property of `JourneyResponse` in the generated types. This should make it optional.