### PR TITLE
feat: consolidate actions across components, including secondaryActions support

### DIFF
--- a/src/components/address/index.njk
+++ b/src/components/address/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set addressLine1= question.fieldName + "_addressLine1" %}
 {% set addressLine2= question.fieldName + "_addressLine2" %}
@@ -97,11 +96,7 @@
                             text: errors[postcode].msg
                         }
                     }) }}
-                    {{ govukButton({
-                        text: continueButtonText,
-                        type: "submit",
-                        attributes: { "data-cy":"button-save-and-continue"}
-                    }) }}
+                    {% include "components/utils/actions.njk" %}
                 {% endcall %}
             </form>
         </div>

--- a/src/components/boolean/index.njk
+++ b/src/components/boolean/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% if question.html %}
     {% set htmlHint %}
@@ -55,11 +54,7 @@
                         items: question.options
                     }) }}
                 {% endif %}
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/boolean/question.js
+++ b/src/components/boolean/question.js
@@ -46,6 +46,7 @@ export default class BooleanQuestion extends RadioQuestion {
 	 * @param {Array.<import('../../questions/options-question.js').Option>} [params.options]
 	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
 	 * @param {boolean} [params.editable]
+	 * @param {import('#question-types').QuestionParameters['viewData']} [params.viewData]
 	 */
 	constructor({
 		title,
@@ -59,7 +60,8 @@ export default class BooleanQuestion extends RadioQuestion {
 		validators,
 		interfaceType = 'radio',
 		options,
-		editable
+		editable,
+		viewData
 	}) {
 		let defaultOptions = options || [
 			{
@@ -90,7 +92,8 @@ export default class BooleanQuestion extends RadioQuestion {
 			options: defaultOptions,
 			validators,
 			html,
-			editable
+			editable,
+			viewData
 		});
 
 		this.interfaceType = interfaceType;

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
     <div class="govuk-grid-row">
@@ -27,11 +26,7 @@
                     },
                     items: question.options
                 }) }}
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/checkbox/question.js
+++ b/src/components/checkbox/question.js
@@ -21,8 +21,9 @@ export default class CheckboxQuestion extends OptionsQuestion {
 	 * @param {string} [params.description]
 	 * @param {Array.<import('../../questions/options-question.js').Option>} params.options
 	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
+	 * @param {import('#question-types').QuestionParameters['viewData']} [params.viewData]
 	 */
-	constructor({ title, question, fieldName, url, pageTitle, description, options, validators }) {
+	constructor({ title, question, fieldName, url, pageTitle, description, options, validators, viewData }) {
 		super({
 			title,
 			question,
@@ -32,7 +33,8 @@ export default class CheckboxQuestion extends OptionsQuestion {
 			pageTitle,
 			description,
 			options,
-			validators
+			validators,
+			viewData
 		});
 
 		this.optionJoinString = defaultOptionJoinString;

--- a/src/components/date-period/index.njk
+++ b/src/components/date-period/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% set startFieldName = question.fieldName + "_start" %}
@@ -117,11 +116,7 @@
                     ]
                 }) }}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/date-time/index.njk
+++ b/src/components/date-time/index.njk
@@ -1,6 +1,5 @@
 {% extends layoutTemplate %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
@@ -117,11 +116,7 @@
                     </fieldset>
                 </div>
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/date/index.njk
+++ b/src/components/date/index.njk
@@ -14,6 +14,7 @@
 {% endif %}
 
 {% block dynQuestionContent %}
+    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="post" novalidate>
@@ -67,18 +68,18 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
-                {% if extraActionButtons|length %}
-                    {% for extraActionButton in extraActionButtons %}
+                {% if secondaryActions|length %}
+                    {% for secondaryAction in secondaryActions %}
                         {{ govukButton({
-                            text: extraActionButton.text,
-                            type: extraActionButton.type,
-                            href: extraActionButton.href,
+                            text: secondaryAction.text,
+                            type: secondaryAction.type,
+                            href: secondaryAction.href,
                             attributes: {
-                                "formaction": extraActionButton.formaction or "",
-                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
-                                "name": extraActionButton.text|lower|replace(" ", "-")
+                                "formaction": secondaryAction.formaction or "",
+                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
+                                "name": secondaryAction.text|lower|replace(" ", "-")
                             },
-                            classes: extraActionButton.classes or "govuk-button--secondary"
+                            classes: secondaryAction.classes or "govuk-button--secondary"
                         }) }}
                     {% endfor %}
                 {% endif %}

--- a/src/components/date/index.njk
+++ b/src/components/date/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set day= question.fieldName + "_day" %}
 {% set month= question.fieldName + "_month" %}
@@ -62,13 +61,7 @@
                     {{ beforeSubmitButton }}
                 {% endif %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
-                {%- include "components/utils/secondary-actions.njk" %}
-
+                {%- include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/date/index.njk
+++ b/src/components/date/index.njk
@@ -14,7 +14,6 @@
 {% endif %}
 
 {% block dynQuestionContent %}
-    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="post" novalidate>
@@ -68,21 +67,8 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
-                {% if secondaryActions|length %}
-                    {% for secondaryAction in secondaryActions %}
-                        {{ govukButton({
-                            text: secondaryAction.text,
-                            type: secondaryAction.type,
-                            href: secondaryAction.href,
-                            attributes: {
-                                "formaction": secondaryAction.formaction or "",
-                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
-                                "name": secondaryAction.text|lower|replace(" ", "-")
-                            },
-                            classes: secondaryAction.classes or "govuk-button--secondary"
-                        }) }}
-                    {% endfor %}
-                {% endif %}
+                {%- include "components/utils/secondary-actions.njk" %}
+
             </form>
         </div>
     </div>

--- a/src/components/identifier/index.njk
+++ b/src/components/identifier/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
     <div class="govuk-grid-row">
@@ -56,11 +55,7 @@
 
                 {% endif %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/manage-list/index.njk
+++ b/src/components/manage-list/index.njk
@@ -1,6 +1,5 @@
 {% extends layoutTemplate %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
     <div class="govuk-grid-row">
@@ -50,11 +49,7 @@
                     <a href="{{ util.trimTrailingSlash(originalUrl) }}/{{ question.addAnotherLink }}" class="govuk-link">Add another</a>
                 </p>
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/multi-field-input/index.njk
+++ b/src/components/multi-field-input/index.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set inputFields = question.value %}
 
@@ -63,12 +62,7 @@
 
                 {% endcall %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
-
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/number-entry/index.njk
+++ b/src/components/number-entry/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
     <div class="govuk-grid-row">
@@ -33,11 +32,7 @@
                     inputmode: 'numeric',
                     spellcheck: false
                 }) }}
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" -%}
             </form>
         </div>
     </div>

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -5,7 +5,6 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block dynQuestionContent %}
-    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="post" novalidate>
@@ -76,21 +75,8 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
-                {% if secondaryActions|length %}
-                    {% for secondaryAction in secondaryActions %}
-                        {{ govukButton({
-                            text: secondaryAction.text,
-                            type: secondaryAction.type,
-                            href: secondaryAction.href,
-                            attributes: {
-                                "formaction": secondaryAction.formaction or "",
-                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
-                                "name": secondaryAction.text|lower|replace(" ", "-")
-                            },
-                            classes: secondaryAction.classes or "govuk-button--secondary"
-                        }) }}
-                    {% endfor %}
-                {% endif %}
+                {%- include "components/utils/secondary-actions.njk" %}
+
             </form>
         </div>
     </div>

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block dynQuestionContent %}
+    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="post" novalidate>
@@ -75,18 +76,18 @@
                     type: "submit",
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
-                {% if extraActionButtons|length %}
-                    {% for extraActionButton in extraActionButtons %}
+                {% if secondaryActions|length %}
+                    {% for secondaryAction in secondaryActions %}
                         {{ govukButton({
-                            text: extraActionButton.text,
-                            type: extraActionButton.type,
-                            href: extraActionButton.href,
+                            text: secondaryAction.text,
+                            type: secondaryAction.type,
+                            href: secondaryAction.href,
                             attributes: {
-                                "formaction": extraActionButton.formaction or "",
-                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
-                                "name": extraActionButton.text|lower|replace(" ", "-")
+                                "formaction": secondaryAction.formaction or "",
+                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
+                                "name": secondaryAction.text|lower|replace(" ", "-")
                             },
-                            classes: extraActionButton.classes or "govuk-button--secondary"
+                            classes: secondaryAction.classes or "govuk-button--secondary"
                         }) }}
                     {% endfor %}
                 {% endif %}

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block dynQuestionContent %}
@@ -70,13 +69,7 @@
 
                 {% endif %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
-                {%- include "components/utils/secondary-actions.njk" %}
-
+                {%- include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block head %}
     {% if not question.disableAccessibleAutocomplete %}
@@ -38,14 +37,8 @@
                     items: question.options
                 }) }}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
 
-                {% include "components/utils/secondary-actions.njk" %}
-
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -12,7 +12,6 @@
 {% endblock %}
 
 {% block dynQuestionContent %}
-    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="POST" novalidate>
@@ -45,21 +44,7 @@
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
 
-                {% if secondaryActions|length %}
-                    {% for secondaryAction in secondaryActions %}
-                        {{ govukButton({
-                            text: secondaryAction.text,
-                            type: secondaryAction.type,
-                            href: secondaryAction.href,
-                            attributes: {
-                                "formaction": secondaryAction.formaction or "",
-                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
-                                "name": secondaryAction.text|lower|replace(" ", "-")
-                            },
-                            classes: secondaryAction.classes or "govuk-button--secondary"
-                        }) }}
-                    {% endfor %}
-                {% endif %}
+                {% include "components/utils/secondary-actions.njk" %}
 
             </form>
         </div>

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block dynQuestionContent %}
+    {% set secondaryActions = secondaryActions or extraActionButtons %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="" method="POST" novalidate>
@@ -44,18 +45,18 @@
                     attributes: { "data-cy":"button-save-and-continue"}
                 }) }}
 
-                {% if extraActionButtons|length %}
-                    {% for extraActionButton in extraActionButtons %}
+                {% if secondaryActions|length %}
+                    {% for secondaryAction in secondaryActions %}
                         {{ govukButton({
-                            text: extraActionButton.text,
-                            type: extraActionButton.type,
-                            href: extraActionButton.href,
+                            text: secondaryAction.text,
+                            type: secondaryAction.type,
+                            href: secondaryAction.href,
                             attributes: {
-                                "formaction": extraActionButton.formaction or "",
-                                "data-cy": "button-" + extraActionButton.text|lower|replace(" ", "-"),
-                                "name": extraActionButton.text|lower|replace(" ", "-")
+                                "formaction": secondaryAction.formaction or "",
+                                "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
+                                "name": secondaryAction.text|lower|replace(" ", "-")
                             },
-                            classes: extraActionButton.classes or "govuk-button--secondary"
+                            classes: secondaryAction.classes or "govuk-button--secondary"
                         }) }}
                     {% endfor %}
                 {% endif %}

--- a/src/components/single-line-input/index.njk
+++ b/src/components/single-line-input/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block dynQuestionContent %}
     <div class="govuk-grid-row">
@@ -70,11 +69,7 @@
 
                 {% endif %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/task-list/index.njk
+++ b/src/components/task-list/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "./task-list-multi-section.njk" import multiTaskList %}
 {% from "./task-list-single-section.njk" import singleTaskList %}
 

--- a/src/components/text-entry-redact/index.njk
+++ b/src/components/text-entry-redact/index.njk
@@ -130,11 +130,7 @@
                     }) }}
                 </div>
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue" }
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
 

--- a/src/components/text-entry/index.njk
+++ b/src/components/text-entry/index.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/label/macro.njk" import govukLabel %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block dynQuestionContent %}
@@ -78,11 +77,7 @@
                     </div>
                 {% endif %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/unit-option-entry/index.njk
+++ b/src/components/unit-option-entry/index.njk
@@ -1,7 +1,6 @@
 {% extends layoutTemplate %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% block dynQuestionContent %}
@@ -37,11 +36,7 @@
 
                 {% endcall %}
 
-                {{ govukButton({
-                    text: continueButtonText,
-                    type: "submit",
-                    attributes: { "data-cy":"button-save-and-continue"}
-                }) }}
+                {% include "components/utils/actions.njk" %}
             </form>
         </div>
     </div>

--- a/src/components/utils/actions.njk
+++ b/src/components/utils/actions.njk
@@ -3,6 +3,12 @@
 {# for backwards compatibility #}
 {%- set secondaryActions = secondaryActions or extraActionButtons -%}
 
+{{ govukButton({
+    text: continueButtonText,
+    type: "submit",
+    attributes: { "data-cy":"button-save-and-continue"}
+}) }}
+
 {% if secondaryActions|length %}
 {% for secondaryAction in secondaryActions %}
     {{ govukButton({

--- a/src/components/utils/actions.njk
+++ b/src/components/utils/actions.njk
@@ -14,15 +14,20 @@
 
 {% if hasSecondaryActions %}
 {% for secondaryAction in secondaryActions %}
+    {%- set name = secondaryAction.text|lower|replace(" ", "-") -%}
+    {%- if secondaryAction.href -%}
+        {# name and formaction aren't valid for <a> tags #}
+        {%- set attributes = {"data-cy": "button-" + name} -%}
+    {%- elseif secondaryAction.formaction and (not secondaryAction.type or secondaryAction.type == "submit") -%}
+        {%- set attributes = {"data-cy": "button-" + name, "name": name, "formaction": secondaryAction.formaction} -%}
+    {%- else -%}
+        {%- set attributes = {"data-cy": "button-" + name, "name": name} -%}
+    {%- endif %}
     {{ govukButton({
         text: secondaryAction.text,
         type: secondaryAction.type,
         href: secondaryAction.href,
-        attributes: {
-            "formaction": secondaryAction.formaction or "",
-            "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
-            "name": secondaryAction.text|lower|replace(" ", "-")
-        },
+        attributes: attributes,
         classes: secondaryAction.classes or "govuk-button--secondary"
     }) }}
 {% endfor %}

--- a/src/components/utils/actions.njk
+++ b/src/components/utils/actions.njk
@@ -2,14 +2,17 @@
 
 {# for backwards compatibility #}
 {%- set secondaryActions = secondaryActions or extraActionButtons -%}
+{%- set hasSecondaryActions = secondaryActions|length > 0 -%}
 
+{% if hasSecondaryActions %}<div class="govuk-button-group">
+{% endif %}
 {{ govukButton({
     text: continueButtonText,
     type: "submit",
     attributes: { "data-cy":"button-save-and-continue"}
 }) }}
 
-{% if secondaryActions|length %}
+{% if hasSecondaryActions %}
 {% for secondaryAction in secondaryActions %}
     {{ govukButton({
         text: secondaryAction.text,
@@ -23,4 +26,5 @@
         classes: secondaryAction.classes or "govuk-button--secondary"
     }) }}
 {% endfor %}
-{% endif %}
+</div>
+{%- endif %}

--- a/src/components/utils/secondary-actions.njk
+++ b/src/components/utils/secondary-actions.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/button/macro.njk" import govukButton -%}
+
+{# for backwards compatibility #}
+{%- set secondaryActions = secondaryActions or extraActionButtons -%}
+
+{% if secondaryActions|length %}
+{% for secondaryAction in secondaryActions %}
+    {{ govukButton({
+        text: secondaryAction.text,
+        type: secondaryAction.type,
+        href: secondaryAction.href,
+        attributes: {
+            "formaction": secondaryAction.formaction or "",
+            "data-cy": "button-" + secondaryAction.text|lower|replace(" ", "-"),
+            "name": secondaryAction.text|lower|replace(" ", "-")
+        },
+        classes: secondaryAction.classes or "govuk-button--secondary"
+    }) }}
+{% endfor %}
+{% endif %}

--- a/src/questions/question-types.d.ts
+++ b/src/questions/question-types.d.ts
@@ -22,12 +22,37 @@ export interface QuestionParameters {
 	// override the action link for this question
 	actionLink?: ActionLink;
 	// static view data for this question
-	viewData?: Record<string, any>;
+	viewData?: {
+		/**
+		 * @deprecated replaced by secondaryActions
+		 */
+		extraActionButtons?: SecondaryAction[];
+		/**
+		 * Secondary action buttons
+		 */
+		secondaryActions?: SecondaryAction[];
+		[key: string]: any;
+	};
 }
 
 export interface ActionLink {
 	text: string;
 	href: string;
+}
+
+export type SecondaryAction = SecondaryActionButton | SecondaryActionLink;
+
+export interface SecondaryActionButton {
+	text: string;
+	type?: string;
+	formaction?: string;
+	classes?: string;
+}
+
+export interface SecondaryActionLink {
+	text: string;
+	href: string;
+	classes?: string;
 }
 
 export interface QuestionViewModel {

--- a/test/secondary-actions.test.js
+++ b/test/secondary-actions.test.js
@@ -1,0 +1,253 @@
+import { describe, it } from 'node:test';
+import assert from 'assert';
+import { COMPONENT_TYPES, Journey, Section } from '../src/index.js';
+import { createAppWithQuestions } from '#test/utils/question-test-utils.js';
+import { createQuestions } from '../src/questions/create-questions.js';
+import { questionClasses } from '../src/questions/questions.js';
+import { questionProps, questionsInOrder } from '#test/questions.js';
+import { assertSnapshot } from '#test/utils/utils.js';
+import { mockRandomUUID } from '#test/mock/uuid.js';
+import { createJourney as createTestJourney, JOURNEY_ID } from '#test/journey.js';
+
+/**
+ * @type {import('../src/questions/question-types.d.ts').SecondaryAction[]}
+ */
+const testSecondaryActions = [
+	{
+		text: 'Save and return',
+		href: '/return',
+		classes: 'govuk-button--secondary'
+	},
+	{
+		text: 'Cancel',
+		type: 'submit',
+		formaction: '/cancel',
+		classes: 'govuk-button--secondary'
+	}
+];
+
+/**
+ * Build question props with secondaryActions appended, from questionsInOrder.
+ */
+const questionPropsWithSecondaryActions = Object.fromEntries(
+	Object.entries(questionProps).map(([k, v]) => [
+		k,
+		{
+			...v,
+			viewData: {
+				...v.viewData,
+				secondaryActions: testSecondaryActions
+			}
+		}
+	])
+);
+
+/**
+ * Question definitions that use the deprecated extraActionButtons
+ */
+const questionPropsWithExtraActionButtons = {
+	testRadioLegacy: {
+		type: COMPONENT_TYPES.RADIO,
+		title: 'Test Radio Legacy',
+		question: 'Pick an option (legacy)',
+		fieldName: 'testRadioLegacy',
+		url: 'test-radio-legacy',
+		options: [
+			{ value: 'a', text: 'Option A' },
+			{ value: 'b', text: 'Option B' }
+		],
+		viewData: {
+			extraActionButtons: testSecondaryActions
+		}
+	}
+};
+
+function createBasicJourney(questions, response) {
+	const section = new Section('Test', 'questions');
+	for (const q of Object.values(questions)) {
+		section.addQuestion(q);
+	}
+	return new Journey({
+		journeyId: JOURNEY_ID,
+		sections: [section],
+		taskListUrl: 'check-your-answers',
+		journeyTemplate: 'views/layout-journey.njk',
+		taskListTemplate: 'views/layout-check-your-answers.njk',
+		journeyTitle: 'Secondary Actions Test',
+		returnToListing: false,
+		makeBaseUrl: () => '/',
+		initialBackLink: '/',
+		response
+	});
+}
+
+function getQuestions(props) {
+	return createQuestions(props, questionClasses, {});
+}
+
+describe('secondary actions', () => {
+	describe('renders secondaryActions buttons', () => {
+		const questionTypes = Object.entries(questionPropsWithSecondaryActions)
+			// filter out manage list sub-questions
+			.filter(([, v]) => questionsInOrder.some((q) => q.fieldName === v.fieldName));
+
+		for (const [, props] of questionTypes) {
+			it(`should render secondary action buttons for ${props.type} component`, async (ctx) => {
+				const questions = getQuestions(questionPropsWithSecondaryActions);
+				const testServer = await createAppWithQuestions(ctx, {
+					journeyId: JOURNEY_ID,
+					questions,
+					createJourneyFn: (q, response) => createTestJourney(q, response)
+				});
+
+				const response = await testServer.get(`/questions/${props.url}`, { redirect: 'manual' });
+				assert.strictEqual(response.status, 200);
+				const text = await response.text();
+
+				// should render the primary submit button
+				assert.match(text, /button-save-and-continue/);
+
+				// should wrap buttons in a button group
+				assert.match(text, /govuk-button-group/);
+
+				// should render the secondary action buttons
+				assert.match(text, /Save and return/);
+				assert.match(text, /button-save-and-return/);
+				assert.match(text, /Cancel/);
+				assert.match(text, /button-cancel/);
+
+				// should have secondary button classes
+				assert.match(text, /govuk-button--secondary/);
+			});
+		}
+	});
+
+	describe('backwards compatibility with extraActionButtons', () => {
+		it('should render buttons when extraActionButtons is used', async (ctx) => {
+			const questions = getQuestions(questionPropsWithExtraActionButtons);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createBasicJourney(q, response)
+			});
+
+			const response = await testServer.get('/questions/test-radio-legacy', { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			// should still render the secondary action buttons via backwards compat
+			assert.match(text, /Save and return/);
+			assert.match(text, /button-save-and-return/);
+			assert.match(text, /Cancel/);
+			assert.match(text, /button-cancel/);
+			assert.match(text, /govuk-button--secondary/);
+		});
+	});
+
+	describe('renders without secondaryActions', () => {
+		it('should render only the submit button when no secondaryActions', async (ctx) => {
+			// Use the first radio question without secondary actions
+			const radioQuestion = questionsInOrder.find((q) => q.type === COMPONENT_TYPES.RADIO);
+			const questionPropsNoActions = {
+				[radioQuestion.fieldName]: { ...radioQuestion }
+			};
+
+			const questions = getQuestions(questionPropsNoActions);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createBasicJourney(q, response)
+			});
+
+			const response = await testServer.get(`/questions/${radioQuestion.url}`, { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			// should render the primary submit button
+			assert.match(text, /button-save-and-continue/);
+
+			// should NOT wrap in a button group
+			assert.doesNotMatch(text, /govuk-button-group/);
+
+			// should NOT render secondary action buttons
+			assert.doesNotMatch(text, /button-save-and-return/);
+			assert.doesNotMatch(text, /button-cancel/);
+		});
+	});
+
+	describe('secondary action button attributes', () => {
+		const firstQuestionProps = Object.values(questionPropsWithSecondaryActions)[0];
+
+		it('should render formaction attribute', async (ctx) => {
+			const questions = getQuestions(questionPropsWithSecondaryActions);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createTestJourney(q, response)
+			});
+
+			const response = await testServer.get(`/questions/${firstQuestionProps.url}`, { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			// Cancel button should have formaction="/cancel"
+			assert.match(text, /formaction="\/cancel"/);
+		});
+
+		it('should render href attribute for link actions', async (ctx) => {
+			const questions = getQuestions(questionPropsWithSecondaryActions);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createTestJourney(q, response)
+			});
+
+			const response = await testServer.get(`/questions/${firstQuestionProps.url}`, { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			// "Save and return" link action should have href="/return"
+			assert.match(text, /href="\/return"/);
+		});
+	});
+
+	describe('snapshots', () => {
+		const radioQuestion = questionsInOrder.find((q) => q.type === COMPONENT_TYPES.RADIO);
+
+		it('should match snapshot with secondary actions', async (ctx) => {
+			const questions = getQuestions(questionPropsWithSecondaryActions);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createTestJourney(q, response)
+			});
+
+			mockRandomUUID(ctx);
+			const response = await testServer.get(`/questions/${radioQuestion.url}`, { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			assertSnapshot(ctx, text, 'secondary-actions-radio.html');
+		});
+
+		it('should match snapshot without secondary actions', async (ctx) => {
+			const questionPropsNoActions = {
+				[radioQuestion.fieldName]: { ...radioQuestion }
+			};
+
+			const questions = getQuestions(questionPropsNoActions);
+			const testServer = await createAppWithQuestions(ctx, {
+				journeyId: JOURNEY_ID,
+				questions,
+				createJourneyFn: (q, response) => createBasicJourney(q, response)
+			});
+
+			mockRandomUUID(ctx);
+			const response = await testServer.get(`/questions/${radioQuestion.url}`, { redirect: 'manual' });
+			assert.strictEqual(response.status, 200);
+			const text = await response.text();
+
+			assertSnapshot(ctx, text, 'secondary-actions-radio-plain.html');
+		});
+	});
+});

--- a/test/snapshots/add-insurance.html
+++ b/test/snapshots/add-insurance.html
@@ -26,9 +26,10 @@
 </div>
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/companions.html
+++ b/test/snapshots/companions.html
@@ -29,7 +29,7 @@
 
 </fieldset>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
 

--- a/test/snapshots/contact-email.html
+++ b/test/snapshots/contact-email.html
@@ -15,9 +15,10 @@
 </div>
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/departure-date.html
+++ b/test/snapshots/departure-date.html
@@ -38,10 +38,10 @@
 </div>
 
 
-
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-activities.html
+++ b/test/snapshots/holiday-activities.html
@@ -31,9 +31,10 @@
 </fieldset>
 </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-arrival.html
+++ b/test/snapshots/holiday-arrival.html
@@ -84,9 +84,10 @@
                     </fieldset>
                 </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-description.html
+++ b/test/snapshots/holiday-description.html
@@ -15,9 +15,10 @@
 
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-destination.html
+++ b/test/snapshots/holiday-destination.html
@@ -37,10 +37,10 @@
 
 </fieldset>
 
-
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-period.html
+++ b/test/snapshots/holiday-period.html
@@ -83,9 +83,10 @@
 </div>
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/holiday-snack.html
+++ b/test/snapshots/holiday-snack.html
@@ -15,9 +15,10 @@
 </div>
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/hotel-address.html
+++ b/test/snapshots/hotel-address.html
@@ -48,9 +48,10 @@
   <input class="govuk-input govuk-input--width-10" id="address-postcode" name="hotelAddress_postcode" type="text" value="" autocomplete="postal-code">
 </div>
 
-                    <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
 
 </fieldset>
             </form>

--- a/test/snapshots/luggage-weight-units.html
+++ b/test/snapshots/luggage-weight-units.html
@@ -52,9 +52,10 @@
 
 </fieldset>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/manage-list-render-questions.html
+++ b/test/snapshots/manage-list-render-questions.html
@@ -89,9 +89,10 @@
                     <a href="/add/00000000-0000-0000-0000-000000000000/first-question" class="govuk-link">Add another</a>
                 </p>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/manage-list-render.html
+++ b/test/snapshots/manage-list-render.html
@@ -83,9 +83,10 @@
                     <a href="/add/00000000-0000-0000-0000-000000000000/first-question" class="govuk-link">Add another</a>
                 </p>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/nights.html
+++ b/test/snapshots/nights.html
@@ -9,9 +9,10 @@
   <input class="govuk-input govuk-input--width-5" id="nights" name="nights" type="text" spellcheck="false" value="" inputmode="numeric">
 </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
-            </form>
+
+</form>
         </div>
     </div>

--- a/test/snapshots/secondary-actions-radio-plain.html
+++ b/test/snapshots/secondary-actions-radio-plain.html
@@ -1,0 +1,46 @@
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate>
+
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      Which type of travel insurance would you like?
+    </h1>
+  </legend>
+
+                        <div class="govuk-form-group">
+  <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType" name="travelInsuranceType" type="radio" value="basic" data-cy="answer-basic">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType">
+        Basic
+      </label>
+    </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType-2" name="travelInsuranceType" type="radio" value="comprehensive" data-cy="answer-comprehensive">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType-2">
+        Comprehensive
+      </label>
+    </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType-3" name="travelInsuranceType" type="radio" value="premium" data-cy="answer-premium">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType-3">
+        Premium
+      </label>
+    </div>
+  </div>
+</div>
+
+
+
+</fieldset>
+
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+  Continue
+</button>
+
+            </form>
+        </div>
+    </div>

--- a/test/snapshots/secondary-actions-radio.html
+++ b/test/snapshots/secondary-actions-radio.html
@@ -1,0 +1,53 @@
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="" method="post" novalidate>
+
+
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      Which type of travel insurance would you like?
+    </h1>
+  </legend>
+
+                        <div class="govuk-form-group">
+  <div class="govuk-radios govuk-radios" data-module="govuk-radios">
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType" name="travelInsuranceType" type="radio" value="basic" data-cy="answer-basic">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType">
+        Basic
+      </label>
+    </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType-2" name="travelInsuranceType" type="radio" value="comprehensive" data-cy="answer-comprehensive">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType-2">
+        Comprehensive
+      </label>
+    </div>
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input" id="travelInsuranceType-3" name="travelInsuranceType" type="radio" value="premium" data-cy="answer-premium">
+      <label class="govuk-label govuk-radios__label" for="travelInsuranceType-3">
+        Premium
+      </label>
+    </div>
+  </div>
+</div>
+
+
+
+</fieldset>
+
+<div class="govuk-button-group">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+  Continue
+</button>
+
+    <a href="/return" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-cy="button-save-and-return">
+  Save and return
+</a>
+    <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" data-cy="button-cancel" name="cancel" formaction="/cancel">
+  Cancel
+</button>
+</div>            </form>
+        </div>
+    </div>

--- a/test/snapshots/secret-wish.html
+++ b/test/snapshots/secret-wish.html
@@ -47,9 +47,10 @@
 </button>
                 </div>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
 

--- a/test/snapshots/travel-class.html
+++ b/test/snapshots/travel-class.html
@@ -18,10 +18,10 @@
 </div>
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
-
 
             </form>
         </div>

--- a/test/snapshots/travel-companions.html
+++ b/test/snapshots/travel-companions.html
@@ -11,9 +11,10 @@
                     <a href="/questions/travel-companions/add/00000000-0000-0000-0000-000000000000/travel-companion-name" class="govuk-link">Add another</a>
                 </p>
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/travel-companions_travel-companion-email.html
+++ b/test/snapshots/travel-companions_travel-companion-email.html
@@ -13,9 +13,10 @@
 
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/travel-companions_travel-companion-name.html
+++ b/test/snapshots/travel-companions_travel-companion-name.html
@@ -13,9 +13,10 @@
 
 
 
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>

--- a/test/snapshots/travel-insurance-type.html
+++ b/test/snapshots/travel-insurance-type.html
@@ -37,10 +37,10 @@
 
 </fieldset>
 
-
-                <button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
+<button type="submit" class="govuk-button" data-module="govuk-button" data-cy="button-save-and-continue">
   Continue
 </button>
+
             </form>
         </div>
     </div>


### PR DESCRIPTION
- Add secondary actions option to all components.
- Renames `extraActionButtons` to `secondaryActions`, but remains backwards compatible.
- Puts action buttons in a group if there are multiple

https://pins-ds.atlassian.net/browse/DF-33