### PR TITLE
fix(task-list): import task list macros with context csrf

### DIFF
--- a/src/components/task-list/index.njk
+++ b/src/components/task-list/index.njk
@@ -2,8 +2,8 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "./task-list-multi-section.njk" import multiTaskList %}
-{% from "./task-list-single-section.njk" import singleTaskList %}
+{% from "./task-list-multi-section.njk" import multiTaskList with context %}
+{% from "./task-list-single-section.njk" import singleTaskList with context %}
 
 {% block dynTaskList %}
     <style {% if cspNonce %}nonce={{ cspNonce }}{% endif %}>


### PR DESCRIPTION
This pull request updates the way macros are imported in the `src/components/task-list/index.njk` file to ensure that the current template context is passed to the imported macros. This allows for the csrf to be passed to the macro