### PR TITLE
fix: validator exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,5 @@
 // Components
 import AddressQuestion from './components/address/question.js';
-import DateValidator from './validator/date-validator.js';
-import EmailValidator from './validator/email-validator.js';
-import StringValidator from './validator/string-validator.js';
 
 export { AddressQuestion };
 export * from './components/boolean/question.js';
@@ -52,24 +49,44 @@ export * from './questions/question-types.js';
 // Section
 export { Section } from './section.js';
 
-// validators
+/**
+ * Validators. Export default class and then wildcard to handle extra types, etc.
+ */
+export { default as AddressValidator } from './validator/address-validator.js';
 export * from './validator/address-validator.js';
+export { default as BaseValidator } from './validator/base-validator.js';
 export * from './validator/base-validator.js';
+export { default as ConditionalRequiredValidator } from './validator/conditional-required-validator.js';
 export * from './validator/conditional-required-validator.js';
+export { default as ConfirmationCheckboxValidator } from './validator/confirmation-checkbox-validator.js';
 export * from './validator/confirmation-checkbox-validator.js';
+export { default as CoordinatesValidator } from './validator/coordinates-validator.js';
 export * from './validator/coordinates-validator.js';
+export { default as DatePeriodValidator } from './validator/date-period-validator.js';
 export * from './validator/date-period-validator.js';
+export { default as DateTimeValidator } from './validator/date-time-validator.js';
 export * from './validator/date-time-validator.js';
-export { DateValidator };
-export { EmailValidator };
+export { default as DateValidator } from './validator/date-validator.js';
+export * from './validator/date-validator.js';
+export { default as DocumentUploadValidator } from './validator/document-upload-validator.js';
 export * from './validator/document-upload-validator.js';
+export { default as EmailValidator } from './validator/email-validator.js';
+export * from './validator/email-validator.js';
+export { default as MultiFieldInputValidator } from './validator/multi-field-input-validator.js';
 export * from './validator/multi-field-input-validator.js';
+export { default as NumericValidator } from './validator/numeric-validator.js';
 export * from './validator/numeric-validator.js';
 export { default as RequiredValidator } from './validator/required-validator.js';
+export * from './validator/required-validator.js';
+export { default as SameAnswerValidator } from './validator/same-answer-validator.js';
 export * from './validator/same-answer-validator.js';
-export { StringValidator };
+export { default as StringValidator } from './validator/string-validator.js';
+export * from './validator/string-validator.js';
+export { default as UnitOptionEntryValidator } from './validator/unit-option-entry-validator.js';
 export * from './validator/unit-option-entry-validator.js';
+export { default as ValidOptionValidator } from './validator/valid-option-validator.js';
 export * from './validator/valid-option-validator.js';
+// Other validation tools
 export * from './validator/validation-error-handler.js';
 export { default as validate } from './validator/validator.js';
 export * from './validator/validator.js';


### PR DESCRIPTION
This PR fixes issues where validator classes could not be imported from the package in TypeScript. 

The barrel export pattern is standardised: `default` classes are exported under their own name, and then a `*` wildcard export also occurs, to ensure that any other exported methods or types are handled.

Existing exports (that may have been missing either the default or the wildcard) are brought in line with this pattern.

In the long term it may be preferable to set up subpath exports in `package.json` so that e.g. `import DatePeriodValidator from '@planning-inspectorate/dynamic-forms/validator/date-period-validator';` could be done in TypeScript. This would remove the requirement for these double exports.