### PR TITLE
fix: make errorMessage param only required if field is required

### DIFF
--- a/src/validator/multi-field-input-validator.js
+++ b/src/validator/multi-field-input-validator.js
@@ -20,13 +20,29 @@ import BaseValidator from './base-validator.js';
  */
 
 /**
- * @typedef {Object} Field
+ * @typedef {Object} FieldBase
  * @property {string} fieldName
- * @property {boolean} required
- * @property {string} errorMessage
  * @property {MinLength} [minLength]
  * @property {MaxLength} [maxLength]
  * @property {Regex} [regex]
+ */
+
+/**
+ * @typedef {FieldBase & {
+ *   required: true,
+ *   errorMessage: string
+ * }} RequiredField
+ */
+
+/**
+ * @typedef {FieldBase & {
+ *   required?: false,
+ *   errorMessage?: string
+ * }} OptionalField
+ */
+
+/**
+ * @typedef {RequiredField | OptionalField} Field
  */
 
 export class MultiFieldInputValidator extends BaseValidator {


### PR DESCRIPTION
For `MultiFieldInputValidator`, split the previous `Field` typedef into more specific types for required and optional fields.