### PR TITLE
Fix/validator exports 2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,5 @@
 // Components
 import AddressQuestion from './components/address/question.js';
-import DateValidator from './validator/date-validator.js';
-import EmailValidator from './validator/email-validator.js';
-import StringValidator from './validator/string-validator.js';
 
 export { AddressQuestion };
 export * from './components/boolean/question.js';
@@ -52,7 +49,7 @@ export * from './questions/question-types.js';
 // Section
 export { Section } from './section.js';
 
-// validators
+// Validators
 export * from './validator/address-validator.js';
 export * from './validator/base-validator.js';
 export * from './validator/conditional-required-validator.js';
@@ -60,16 +57,17 @@ export * from './validator/confirmation-checkbox-validator.js';
 export * from './validator/coordinates-validator.js';
 export * from './validator/date-period-validator.js';
 export * from './validator/date-time-validator.js';
-export { DateValidator };
-export { EmailValidator };
+export * from './validator/date-validator.js';
 export * from './validator/document-upload-validator.js';
+export * from './validator/email-validator.js';
 export * from './validator/multi-field-input-validator.js';
 export * from './validator/numeric-validator.js';
-export { default as RequiredValidator } from './validator/required-validator.js';
+export * from './validator/required-validator.js';
 export * from './validator/same-answer-validator.js';
-export { StringValidator };
+export * from './validator/string-validator.js';
 export * from './validator/unit-option-entry-validator.js';
 export * from './validator/valid-option-validator.js';
+// Other validation tools
 export * from './validator/validation-error-handler.js';
 export { default as validate } from './validator/validator.js';
 export * from './validator/validator.js';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as api from './index.js';
+
+describe('public API', () => {
+	it('should re-export key validators and validation utilities', () => {
+		assert.equal(typeof api.validate, 'function');
+		assert.equal(typeof api.buildValidateBody, 'function');
+
+		assert.equal(typeof api.validationErrorHandler, 'function');
+		assert.equal(typeof api.buildValidationErrorHandler, 'function');
+		assert.equal(typeof api.expressValidationErrorsToGovUkErrorList, 'function');
+
+		assert.equal(typeof api.BaseValidator, 'function');
+		assert.equal(typeof api.RequiredValidator, 'function');
+		assert.equal(typeof api.EmailValidator, 'function');
+		assert.equal(typeof api.ValidOptionValidator, 'function');
+		assert.equal(typeof api.StringValidator, 'function');
+		assert.equal(typeof api.NumericValidator, 'function');
+		assert.equal(typeof api.DateValidator, 'function');
+		assert.equal(typeof api.DateTimeValidator, 'function');
+		assert.equal(typeof api.DatePeriodValidator, 'function');
+		assert.equal(typeof api.AddressValidator, 'function');
+		assert.equal(typeof api.MultiFieldInputValidator, 'function');
+		assert.equal(typeof api.UnitOptionEntryValidator, 'function');
+		assert.equal(typeof api.ConditionalRequiredValidator, 'function');
+		assert.equal(typeof api.ConfirmationCheckboxValidator, 'function');
+		assert.equal(typeof api.CoordinatesValidator, 'function');
+		assert.equal(typeof api.DocumentUploadValidator, 'function');
+		assert.equal(typeof api.SameAnswerValidator, 'function');
+	});
+
+	it('should re-export key utility functions', () => {
+		assert.equal(typeof api.buildSaveDataToSession, 'function');
+		assert.equal(typeof api.saveDataToSession, 'function');
+		assert.equal(typeof api.clearDataFromSession, 'function');
+		assert.equal(typeof api.buildGetJourneyResponseFromSession, 'function');
+
+		assert.equal(typeof api.nl2br, 'function');
+		assert.equal(typeof api.capitalize, 'function');
+		assert.equal(typeof api.trimTrailingSlash, 'function');
+		assert.equal(typeof api.toArray, 'function');
+
+		assert.equal(typeof api.getPersistedNumberAnswer, 'function');
+		assert.equal(typeof api.getConditionalFieldName, 'function');
+		assert.equal(typeof api.getConditionalAnswer, 'function');
+		assert.equal(typeof api.conditionalIsJustHTML, 'function');
+	});
+
+	it('should re-export key top-level classes and factories', () => {
+		assert.equal(typeof api.AddressQuestion, 'function');
+		assert.equal(typeof api.Question, 'function');
+		assert.equal(typeof api.createQuestions, 'function');
+		assert.equal(typeof api.questionClasses, 'object');
+		assert.equal(typeof api.Section, 'function');
+		assert.equal(typeof api.Journey, 'function');
+		assert.equal(typeof api.JourneyResponse, 'function');
+	});
+});

--- a/src/validator/address-validator.js
+++ b/src/validator/address-validator.js
@@ -28,7 +28,7 @@ export const postcodeMinLength = 5;
  * enforces address fields are within allowed parameters
  * @class
  */
-export default class AddressValidator extends BaseValidator {
+export class AddressValidator extends BaseValidator {
 	/**
 	 * creates an instance of an AddressValidator
 	 * @param {Object} [opts]
@@ -155,3 +155,5 @@ export default class AddressValidator extends BaseValidator {
 		return false;
 	}
 }
+
+export default AddressValidator;

--- a/src/validator/base-validator.js
+++ b/src/validator/base-validator.js
@@ -2,7 +2,7 @@
  * @abstract
  * @class BaseValidator
  */
-export default class BaseValidator {
+export class BaseValidator {
 	/**
 	 * @type {string} error message to display to user
 	 */
@@ -14,3 +14,5 @@ export default class BaseValidator {
 		}
 	}
 }
+
+export default BaseValidator;

--- a/src/validator/conditional-required-validator.js
+++ b/src/validator/conditional-required-validator.js
@@ -11,7 +11,7 @@ import { toArray } from '#src/lib/utils.js';
  * enforces a field is not empty when condition is satisfied
  * @class
  */
-export default class ConditionalRequiredValidator extends BaseValidator {
+export class ConditionalRequiredValidator extends BaseValidator {
 	/**
 	 * @type {string} error message to display to user
 	 */
@@ -58,3 +58,5 @@ export default class ConditionalRequiredValidator extends BaseValidator {
 		});
 	}
 }
+
+export default ConditionalRequiredValidator;

--- a/src/validator/confirmation-checkbox-validator.js
+++ b/src/validator/confirmation-checkbox-validator.js
@@ -10,14 +10,14 @@ import BaseValidator from './base-validator.js';
  * enforces a confirmation checkbox is checked before proceeding
  * @class
  */
-export default class ConfirmationCheckboxValidator extends BaseValidator {
+export class ConfirmationCheckboxValidator extends BaseValidator {
 	/**
 	 * @type {string} error message to display to user
 	 */
 	errorMessage = 'Please check the checkbox';
 
 	/**
-	 * creates an instance of a ConditionalRequiredValidator
+	 * creates an instance of a ConfirmationCheckboxValidator
 	 * @param {Object} params
 	 * @param {string} params.checkboxName
 	 * @param {string} params.errorMessage - custom error message to show on validation failure
@@ -36,3 +36,5 @@ export default class ConfirmationCheckboxValidator extends BaseValidator {
 		return body(this.checkboxName).notEmpty().withMessage(this.errorMessage);
 	}
 }
+
+export default ConfirmationCheckboxValidator;

--- a/src/validator/coordinates-validator.js
+++ b/src/validator/coordinates-validator.js
@@ -8,7 +8,7 @@ export const requiredCoordinateLength = 6;
  * @property {string} title
  * @property {string} fieldName
  */
-export default class CoordinatesValidator extends BaseValidator {
+export class CoordinatesValidator extends BaseValidator {
 	/**
 	 * @param {CoordinateField} northing
 	 * @param {CoordinateField} easting
@@ -55,3 +55,5 @@ export default class CoordinatesValidator extends BaseValidator {
 		];
 	}
 }
+
+export default CoordinatesValidator;

--- a/src/validator/date-period-validator.js
+++ b/src/validator/date-period-validator.js
@@ -20,7 +20,7 @@ import { parseDateInput, startOfDay } from '../lib/date-utils.js';
  * enforces a user has entered a valid date period
  * @class
  */
-export default class DatePeriodValidator extends BaseValidator {
+export class DatePeriodValidator extends BaseValidator {
 	/** @type {DateValidationSettings} */
 	dateValidationSettings;
 
@@ -208,3 +208,5 @@ export default class DatePeriodValidator extends BaseValidator {
 		return isValid(parsedDate);
 	}
 }
+
+export default DatePeriodValidator;

--- a/src/validator/date-time-validator.js
+++ b/src/validator/date-time-validator.js
@@ -9,7 +9,7 @@ import DateValidator from './date-validator.js';
  * enforces a user has entered a valid date
  * @class
  */
-export default class DateTimeValidator extends DateValidator {
+export class DateTimeValidator extends DateValidator {
 	/**
 	 * creates an instance of a DateTimeValidator
 	 * @param {string} timeInputLabel - string representing the time fields as displayed on the UI as part of an error message
@@ -72,3 +72,5 @@ export default class DateTimeValidator extends DateValidator {
 		];
 	}
 }
+
+export default DateTimeValidator;

--- a/src/validator/date-validator.js
+++ b/src/validator/date-validator.js
@@ -20,7 +20,7 @@ import { endOfDay, parseDateInput, startOfDay } from '../lib/date-utils.js';
  * enforces a user has entered a valid date
  * @class
  */
-export default class DateValidator extends BaseValidator {
+export class DateValidator extends BaseValidator {
 	/** @type {DateValidationSettings} */
 	dateValidationSettings;
 
@@ -197,3 +197,5 @@ export default class DateValidator extends BaseValidator {
 		return isValid(parsedDate);
 	}
 }
+
+export default DateValidator;

--- a/src/validator/document-upload-validator.js
+++ b/src/validator/document-upload-validator.js
@@ -1,7 +1,7 @@
 import BaseValidator from './base-validator.js';
 import { body } from 'express-validator';
 
-export default class DocumentUploadValidator extends BaseValidator {
+export class DocumentUploadValidator extends BaseValidator {
 	/**
 	 * @param {string} fieldName
 	 * @param {string} errorMessage
@@ -26,3 +26,5 @@ export default class DocumentUploadValidator extends BaseValidator {
 		];
 	}
 }
+
+export default DocumentUploadValidator;

--- a/src/validator/email-validator.js
+++ b/src/validator/email-validator.js
@@ -11,7 +11,7 @@ import BaseValidator from './base-validator.js';
  * @property {string} [errorMessage] - Custom error message
  */
 
-export default class EmailValidator extends BaseValidator {
+export class EmailValidator extends BaseValidator {
 	/**
 	 * @param {Object} params
 	 * @param {EmailValidationOptions} [params.options] - Email validation options
@@ -39,3 +39,5 @@ export default class EmailValidator extends BaseValidator {
 		return body(fieldName).isEmail(this.options).withMessage(this.errorMessage);
 	}
 }
+
+export default EmailValidator;

--- a/src/validator/multi-field-input-validator.js
+++ b/src/validator/multi-field-input-validator.js
@@ -29,7 +29,7 @@ import BaseValidator from './base-validator.js';
  * @property {Regex} [regex]
  */
 
-export default class MultiFieldInputValidator extends BaseValidator {
+export class MultiFieldInputValidator extends BaseValidator {
 	/**
 	 * @param {Object} params
 	 * @param {Field[]} [params.fields]
@@ -95,3 +95,5 @@ export default class MultiFieldInputValidator extends BaseValidator {
 		return field.required;
 	}
 }
+
+export default MultiFieldInputValidator;

--- a/src/validator/numeric-validator.js
+++ b/src/validator/numeric-validator.js
@@ -14,7 +14,7 @@ import BaseValidator from './base-validator.js';
  * @property {String} maxMessage
  */
 
-export default class NumericValidator extends BaseValidator {
+export class NumericValidator extends BaseValidator {
 	/**
 	 * @param {Object} params
 	 * @param {number} [params.min]
@@ -54,3 +54,5 @@ export default class NumericValidator extends BaseValidator {
 		return chain;
 	}
 }
+
+export default NumericValidator;

--- a/src/validator/required-validator.js
+++ b/src/validator/required-validator.js
@@ -10,7 +10,7 @@ import BaseValidator from './base-validator.js';
  * enforces a field is not empty
  * @class
  */
-export default class RequiredValidator extends BaseValidator {
+export class RequiredValidator extends BaseValidator {
 	/**
 	 * @type {string} error message to display to user
 	 */
@@ -36,3 +36,5 @@ export default class RequiredValidator extends BaseValidator {
 		return body(questionObj.fieldName).notEmpty().withMessage(this.errorMessage);
 	}
 }
+
+export default RequiredValidator;

--- a/src/validator/same-answer-validator.js
+++ b/src/validator/same-answer-validator.js
@@ -4,7 +4,7 @@ import BaseValidator from './base-validator.js';
 /**
  * Universal validator to ensure the answer to the current question is not the same as another question's answer
  */
-export default class SameAnswerValidator extends BaseValidator {
+export class SameAnswerValidator extends BaseValidator {
 	/**
 	 * @param {string[]} fieldNamesToCompare - field name to compare against
 	 * @param {string} [errorMessage]
@@ -30,3 +30,5 @@ export default class SameAnswerValidator extends BaseValidator {
 		});
 	}
 }
+
+export default SameAnswerValidator;

--- a/src/validator/string-validator.js
+++ b/src/validator/string-validator.js
@@ -19,7 +19,7 @@ import BaseValidator from './base-validator.js';
  * @property {String} [regexMessage]
  */
 
-export default class StringValidator extends BaseValidator {
+export class StringValidator extends BaseValidator {
 	minLength = {
 		minLength: 0,
 		minLengthMessage: ''
@@ -79,3 +79,5 @@ export default class StringValidator extends BaseValidator {
 		return chain;
 	}
 }
+
+export default StringValidator;

--- a/src/validator/unit-option-entry-validator.js
+++ b/src/validator/unit-option-entry-validator.js
@@ -11,7 +11,7 @@ import { toArray } from '#src/lib/utils.js';
  * enforces a field is not empty when condition is satisfied
  * @class
  */
-export default class UnitOptionEntryValidator extends BaseValidator {
+export class UnitOptionEntryValidator extends BaseValidator {
 	/**
 	 * @param {Object} params
 	 * @param {string} [params.errorMessage]
@@ -87,3 +87,5 @@ export default class UnitOptionEntryValidator extends BaseValidator {
 		});
 	}
 }
+
+export default UnitOptionEntryValidator;

--- a/src/validator/valid-option-validator.js
+++ b/src/validator/valid-option-validator.js
@@ -11,9 +11,9 @@ import { toArray } from '#src/lib/utils.js';
  * enforces a field is within the question's predefined list of options
  * @class
  */
-export default class ValidOptionValidator extends BaseValidator {
+export class ValidOptionValidator extends BaseValidator {
 	/**
-	 * creates an instance of a RequiredValidator
+	 * creates an instance of a ValidOptionValidator
 	 * @param {string} [errorMessage] - custom error message to show on validation failure
 	 */
 	constructor(errorMessage) {
@@ -40,3 +40,5 @@ export default class ValidOptionValidator extends BaseValidator {
 			.withMessage(this.errorMessage);
 	}
 }
+
+export default ValidOptionValidator;


### PR DESCRIPTION
This PR fixes issues where validator classes could not be imported from the package in TypeScript.

All validator classes now use named exports, and the main `index.js` file re-exports them consistently. Default exports are added for backwards compatibility.

A test has been added to ensure the public API exposes all key validators and utilities as intended.
