### PR TITLE
Fix/multi field input types

### DIFF
--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -11,32 +11,11 @@ import { nl2br } from '../../lib/utils.js';
  */
 
 /**
- * @typedef {Object} Suffix
- * @property {string} text
- * @property {string} [classes] optional property, used to add classes to the suffix/prefix
- */
-
-/**
- * @typedef {Object} InputField
- * @property {string} fieldName
- * @property {string} label
- * @property {string} [formatJoinString] optional property, used by formatAnswerForSummary (eg task list display), effective default to line break
- * @property {string} [formatPrefix] optional property, used by formatAnswerForSummary (eg task list display), to prefix answer
- * @property {function} [formatTextFunction] optional property, used to format the answer for display and value in question
- * @property {Record<string, string>} [attributes] optional property, used to add html attributes to the field
- * @property {Suffix} [suffix] optional property, used to add a suffix to the field
- * @property {Suffix} [prefix] optional property, used to add a prefix to the field
- */
-
-/**
  * @class
  */
 export default class MultiFieldInputQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input
-	 * @param {InputField[]} params.inputFields input fields
+	 * @param {import('#src/questions/question-props.d.ts').MultiFieldInputQuestionProps} params
 	 */
 	constructor({ inputFields, ...params }) {
 		super({

--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -32,22 +32,17 @@ import { nl2br } from '../../lib/utils.js';
  * @class
  */
 export default class MultiFieldInputQuestion extends Question {
-	/** @type {Record<string, string>} */
-	inputAttributes;
-
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
 	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input
 	 * @param {InputField[]} params.inputFields input fields
 	 */
-	constructor({ label, inputAttributes = {}, inputFields, ...params }) {
+	constructor({ inputFields, ...params }) {
 		super({
 			...params,
 			viewFolder: 'multi-field-input'
 		});
-		this.label = label;
-		this.inputAttributes = inputAttributes;
 
 		if (inputFields) {
 			this.inputFields = inputFields;
@@ -63,14 +58,6 @@ export default class MultiFieldInputQuestion extends Question {
 				value: this.#formatValue(answers[inputField.fieldName], inputField.formatTextFunction)
 			};
 		});
-	}
-
-	/**
-	 * @param {import('#question').QuestionViewModel} viewModel
-	 */
-	addCustomDataToViewModel(viewModel) {
-		viewModel.question.label = this.label;
-		viewModel.question.attributes = this.inputAttributes;
 	}
 
 	/**

--- a/src/components/multi-field-input/question.test.js
+++ b/src/components/multi-field-input/question.test.js
@@ -9,7 +9,6 @@ const FIELDNAME = 'field-name';
 const VALIDATORS = [1, 2];
 const HTML = '/path/to/html.njk';
 const HINT = 'hint';
-const LABEL = 'A label';
 const INPUTFIELDS = [{ fieldName: 'testField1' }, { fieldName: 'testField2' }];
 
 function createMultiFieldInputQuestion(
@@ -19,7 +18,6 @@ function createMultiFieldInputQuestion(
 	validators = VALIDATORS,
 	html = HTML,
 	hint = HINT,
-	label = LABEL,
 	inputFields = INPUTFIELDS
 ) {
 	return new MultiFieldInputQuestion({
@@ -29,7 +27,6 @@ function createMultiFieldInputQuestion(
 		validators: validators,
 		html: html,
 		hint: hint,
-		label: label,
 		inputFields: inputFields
 	});
 }
@@ -45,13 +42,12 @@ describe('./src/dynamic-forms/components/multi-field-input/question.js', () => {
 		assert.strictEqual(testQuestion.validators, VALIDATORS);
 		assert.strictEqual(testQuestion.html, HTML);
 		assert.strictEqual(testQuestion.hint, HINT);
-		assert.strictEqual(testQuestion.label, LABEL);
 		assert.strictEqual(testQuestion.inputFields, INPUTFIELDS);
 	});
 
 	it('should throw error if no inputFields parameter is passed to the constructor', () => {
 		assert.throws(() => {
-			createMultiFieldInputQuestion(TITLE, QUESTION, FIELDNAME, VALIDATORS, HTML, HINT, LABEL, null);
+			createMultiFieldInputQuestion(TITLE, QUESTION, FIELDNAME, VALIDATORS, HTML, HINT, null);
 		}, new Error('inputFields are mandatory'));
 	});
 
@@ -118,7 +114,7 @@ describe('./src/dynamic-forms/components/multi-field-input/question.js', () => {
 		});
 		it('should set inputFields with formatted values from journey response if formatTextFunction is provided', () => {
 			const formatTextFunction = (value) => `Formatted: ${value}`;
-			const question = createMultiFieldInputQuestion(TITLE, QUESTION, FIELDNAME, VALIDATORS, HTML, HINT, LABEL, [
+			const question = createMultiFieldInputQuestion(TITLE, QUESTION, FIELDNAME, VALIDATORS, HTML, HINT, [
 				{ fieldName: 'testField1', formatTextFunction },
 				{ fieldName: 'testField2', formatTextFunction }
 			]);

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -46,10 +46,20 @@ type Option =
 	  }
 	| { divider?: string };
 
+type Affix = {
+	text: string;
+	classes?: string;
+};
+
 interface InputField {
 	fieldName: string;
 	label: string;
-	formatJoinString?: string; // optional property, used by formatAnswerForSummary (eg task list display), effective default to line break
+	formatJoinString?: string; // used by formatAnswerForSummary (e.g. task list display), effective default to line break
+	formatPrefix?: string; // used by formatAnswerForSummary (e.g. task list display), to prefix answer
+	formatTextFunction?: (text: string) => string; // used to format the answer for display and value in question
+	attributes?: Record<string, string>; // used to add HTML attributes to the field
+	suffix?: Affix; // used to add a suffix to the field
+	prefix?: Affix; // used to add a prefix to the field
 	hint?: string;
 }
 
@@ -109,7 +119,7 @@ type EmailQuestionProps = CommonQuestionProps & {
 	type: 'email';
 };
 
-type MultiFieldInputQuestionProps = CommonQuestionProps & {
+export type MultiFieldInputQuestionProps = CommonQuestionProps & {
 	type: 'multi-field-input';
 	inputFields: InputField[];
 };

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -111,9 +111,7 @@ type EmailQuestionProps = CommonQuestionProps & {
 
 type MultiFieldInputQuestionProps = CommonQuestionProps & {
 	type: 'multi-field-input';
-	inputAttributes?: Record<string, string>;
 	inputFields: InputField[];
-	formatType?: 'contactDetails' | 'standard';
 };
 
 type NumberEntryQuestionProps = CommonQuestionProps & {


### PR DESCRIPTION
Improve type definitions for `MultiFieldInputQuestion`.

1. Remove duplicate typedefs for the question properties: define in `question-props.d.ts` and import.
2. I couldn't find any usage of the `label` or `inputAttributes` params - they are not used in the template, and setting them has no effect on the question - so I removed them, and therefore also removed `addCustomDataToViewModel`
3. The `formatType` param was defined in `question-props.d.ts` but not used by the question, so I removed it