### PR TITLE
fix(types): align action types in formatAnswerForSummary function

### DIFF
--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -401,11 +401,7 @@ export class Question {
 	 * @returns {Array<{
 	 *   key: string;
 	 *   value: string | Object;
-	 *   action: {
-	 *     href: string;
-	 *     text: string;
-	 *     visuallyHiddenText: string;
-	 *   };
+	 *   action?: ActionView | ActionView[];
 	 * }>}
 	 */
 	formatAnswerForSummary(sectionSegment, journey, answer, capitals = true) {


### PR DESCRIPTION
The return type of `formatAnswerForSummary` did not match the updated return type of `getAction`, so Typescript was flagging classes extending `Question` as being incompatible. This brings them in line.