### PR TITLE
fix: question component exports so they are accessible from both TS and JS

### DIFF
--- a/src/components/address/question.js
+++ b/src/components/address/question.js
@@ -5,7 +5,7 @@ import { Address } from '../../lib/address.js';
 import { nl2br } from '../../lib/utils.js';
 import AddressValidator from '../../validator/address-validator.js';
 
-export default class AddressQuestion extends Question {
+export class AddressQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 */
@@ -135,3 +135,5 @@ export default class AddressQuestion extends Question {
 		}
 	}
 }
+
+export default AddressQuestion;

--- a/src/components/boolean/question.js
+++ b/src/components/boolean/question.js
@@ -31,7 +31,7 @@ export const booleanToYesNoOrNull = (value) => {
 	return null;
 };
 
-export default class BooleanQuestion extends RadioQuestion {
+export class BooleanQuestion extends RadioQuestion {
 	/**
 	 * @param {Object} params
 	 * @param {string} params.title
@@ -120,3 +120,5 @@ export default class BooleanQuestion extends RadioQuestion {
 		return { answers };
 	}
 }
+
+export default BooleanQuestion;

--- a/src/components/checkbox/question.js
+++ b/src/components/checkbox/question.js
@@ -10,7 +10,7 @@ const defaultOptionJoinString = ',';
  * @property {string} conditional the conditional text input
  */
 
-export default class CheckboxQuestion extends OptionsQuestion {
+export class CheckboxQuestion extends OptionsQuestion {
 	/**
 	 * @param {Object} params
 	 * @param {string} params.title
@@ -86,3 +86,5 @@ export default class CheckboxQuestion extends OptionsQuestion {
 		return super.formatAnswerForSummary(sectionSegment, journey, formattedAnswer, false);
 	}
 }
+
+export default CheckboxQuestion;

--- a/src/components/date-period/question.js
+++ b/src/components/date-period/question.js
@@ -9,7 +9,7 @@ const DEFAULT_DATE_FORMAT = 'HH:mm d MMMM yyyy';
  * Represents a date period, two dates which make up a period or range
  * @class
  */
-export default class DatePeriodQuestion extends Question {
+export class DatePeriodQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.dateFormat]
@@ -153,3 +153,5 @@ export default class DatePeriodQuestion extends Question {
 		return [{ key: key, value: formattedAnswer, action: action }];
 	}
 }
+
+export default DatePeriodQuestion;

--- a/src/components/date-time/question.js
+++ b/src/components/date-time/question.js
@@ -4,7 +4,7 @@ import { formatDateForDisplay, parseDateInput } from '../../lib/date-utils.js';
 const DEFAULT_DATE_FORMAT = 'd MMMM yyyy';
 const DEFAULT_TIME_FORMAT = 'HH:mma';
 
-export default class DateTimeQuestion extends Question {
+export class DateTimeQuestion extends Question {
 	static AM = 'am';
 	static PM = 'pm';
 
@@ -123,3 +123,5 @@ export default class DateTimeQuestion extends Question {
 		}
 	}
 }
+
+export default DateTimeQuestion;

--- a/src/components/date/question.js
+++ b/src/components/date/question.js
@@ -6,7 +6,7 @@ const DEFAULT_DATE_FORMAT = 'd MMMM yyyy';
 /**
  * @class
  */
-export default class DateQuestion extends Question {
+export class DateQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.dateFormat]
@@ -82,3 +82,5 @@ export default class DateQuestion extends Question {
 		return [{ key: key, value: formattedAnswer, action: action }];
 	}
 }
+
+export default DateQuestion;

--- a/src/components/email/question.js
+++ b/src/components/email/question.js
@@ -13,7 +13,7 @@ import SingleLineInputQuestion from '../single-line-input/question.js';
  * Automatically sets the input type to "email" and adds appropriate attributes
  * @class
  */
-export default class EmailQuestion extends SingleLineInputQuestion {
+export class EmailQuestion extends SingleLineInputQuestion {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
@@ -53,3 +53,5 @@ export default class EmailQuestion extends SingleLineInputQuestion {
 		return super.formatAnswerForSummary(sectionSegment, journey, answer, false);
 	}
 }
+
+export default EmailQuestion;

--- a/src/components/identifier/question.js
+++ b/src/components/identifier/question.js
@@ -1,6 +1,6 @@
 import { Question } from '#question';
 
-export default class IdentifierQuestion extends Question {
+export class IdentifierQuestion extends Question {
 	/** @type {string|undefined} page h1, optional, will default to use question's label */
 	pageHeading;
 	/** @type {string} css classes to apply to input element */
@@ -29,3 +29,5 @@ export default class IdentifierQuestion extends Question {
 		viewModel.question.label = this.label;
 	}
 }
+
+export default IdentifierQuestion;

--- a/src/components/manage-list/question.js
+++ b/src/components/manage-list/question.js
@@ -11,7 +11,7 @@ import { MANAGE_LIST_ACTIONS } from './manage-list-actions.js';
  * @property {string} [confirmationQuestion] - the name of the confirmation question to use when removing an item, default 'confirm'
  */
 
-export default class ManageListQuestion extends Question {
+export class ManageListQuestion extends Question {
 	/** @type {import('../../section.js').Section} */
 	#section;
 	/** @type {boolean} */
@@ -187,3 +187,5 @@ export default class ManageListQuestion extends Question {
 		this.#section = section;
 	}
 }
+
+export default ManageListQuestion;

--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -13,7 +13,7 @@ import { nl2br } from '../../lib/utils.js';
 /**
  * @class
  */
-export default class MultiFieldInputQuestion extends Question {
+export class MultiFieldInputQuestion extends Question {
 	/**
 	 * @param {import('#src/questions/question-props.d.ts').MultiFieldInputQuestionProps} params
 	 */
@@ -115,3 +115,5 @@ export default class MultiFieldInputQuestion extends Question {
 		return valueToFormat;
 	}
 }
+
+export default MultiFieldInputQuestion;

--- a/src/components/number-entry/question.js
+++ b/src/components/number-entry/question.js
@@ -1,7 +1,7 @@
 import { Question } from '#question';
 import { getPersistedNumberAnswer } from '../utils/persisted-number-answer.js';
 
-export default class NumberEntryQuestion extends Question {
+export class NumberEntryQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {string} [params.suffix]
@@ -48,3 +48,5 @@ export default class NumberEntryQuestion extends Question {
 		return super.formatAnswerForSummary(sectionSegment, journey, answer, false);
 	}
 }
+
+export default NumberEntryQuestion;

--- a/src/components/radio/question.js
+++ b/src/components/radio/question.js
@@ -1,6 +1,6 @@
 import OptionsQuestion from '../../questions/options-question.js';
 
-export default class RadioQuestion extends OptionsQuestion {
+export class RadioQuestion extends OptionsQuestion {
 	/**
 	 * @param {Object} params
 	 * @param {string} params.title
@@ -90,3 +90,5 @@ export default class RadioQuestion extends OptionsQuestion {
 		return super.formatAnswerForSummary(sectionSegment, journey, answer);
 	}
 }
+
+export default RadioQuestion;

--- a/src/components/select/question.js
+++ b/src/components/select/question.js
@@ -1,6 +1,6 @@
 import OptionsQuestion from '../../questions/options-question.js';
 
-export default class SelectQuestion extends OptionsQuestion {
+export class SelectQuestion extends OptionsQuestion {
 	#disableAccessibleAutocomplete;
 	/**
 	 * @param {Object} params
@@ -84,3 +84,5 @@ export default class SelectQuestion extends OptionsQuestion {
 		return super.formatAnswerForSummary(sectionSegment, journey, answer);
 	}
 }
+
+export default SelectQuestion;

--- a/src/components/single-line-input/question.js
+++ b/src/components/single-line-input/question.js
@@ -3,7 +3,7 @@ import { Question } from '#question';
 /**
  * @class
  */
-export default class SingleLineInputQuestion extends Question {
+export class SingleLineInputQuestion extends Question {
 	/** @type {Record<string, string>} */
 	inputAttributes;
 
@@ -37,3 +37,5 @@ export default class SingleLineInputQuestion extends Question {
 		viewModel.question.classes = this.classes;
 	}
 }
+
+export default SingleLineInputQuestion;

--- a/src/components/text-entry-redact/question.js
+++ b/src/components/text-entry-redact/question.js
@@ -7,7 +7,7 @@ export const TRUNCATED_MAX_LENGTH = 500;
 /**
  * @class
  */
-export default class TextEntryRedactQuestion extends Question {
+export class TextEntryRedactQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {import('../text-entry/question.js').TextEntryCheckbox} [params.textEntryCheckbox]
@@ -105,3 +105,5 @@ export default class TextEntryRedactQuestion extends Question {
 		return super.formatAnswerForSummary(sectionSegment, journey, toShow, capitals);
 	}
 }
+
+export default TextEntryRedactQuestion;

--- a/src/components/text-entry/question.js
+++ b/src/components/text-entry/question.js
@@ -17,7 +17,7 @@ import { Question } from '#question';
 /**
  * @class
  */
-export default class TextEntryQuestion extends Question {
+export class TextEntryQuestion extends Question {
 	/**
 	 * @param {import('#question-types').QuestionParameters} params
 	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
@@ -41,3 +41,5 @@ export default class TextEntryQuestion extends Question {
 		viewModel.question.textEntryCheckbox = this.textEntryCheckbox;
 	}
 }
+
+export default TextEntryQuestion;

--- a/src/components/unit-option-entry/question.js
+++ b/src/components/unit-option-entry/question.js
@@ -30,7 +30,7 @@ const defaultOptionJoinString = ',';
  *}} UnitOption
  */
 
-export default class UnitOptionEntryQuestion extends Question {
+export class UnitOptionEntryQuestion extends Question {
 	/** @type {Array<UnitOption>} */
 	options;
 
@@ -180,3 +180,5 @@ export default class UnitOptionEntryQuestion extends Question {
 		return super.formatAnswerForSummary(sectionSegment, journey, formattedAnswer, false);
 	}
 }
+
+export default UnitOptionEntryQuestion;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 // Components
-import AddressQuestion from './components/address/question.js';
-
-export { AddressQuestion };
+export * from './components/address/question.js';
 export * from './components/boolean/question.js';
 export * from './components/checkbox/question.js';
 export * from './components/date/question.js';
 export * from './components/date-period/question.js';
+export * from './components/date-time/question.js';
+export * from './components/email/question.js';
+export * from './components/manage-list/question.js';
 export * from './components/multi-field-input/question.js';
 export * from './components/number-entry/question.js';
 export * from './components/radio/question.js';
@@ -14,6 +15,8 @@ export * from './components/single-line-input/question.js';
 export * from './components/text-entry/question.js';
 export * from './components/text-entry-redact/question.js';
 export * from './components/unit-option-entry/question.js';
+
+// Utils
 export * from './components/utils/persisted-number-answer.js';
 export * from './components/utils/question-has-answer.js';
 export * from './components/utils/question-utils.js';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -49,12 +49,37 @@ describe('public API', () => {
 	});
 
 	it('should re-export key top-level classes and factories', () => {
-		assert.equal(typeof api.AddressQuestion, 'function');
 		assert.equal(typeof api.Question, 'function');
 		assert.equal(typeof api.createQuestions, 'function');
 		assert.equal(typeof api.questionClasses, 'object');
 		assert.equal(typeof api.Section, 'function');
 		assert.equal(typeof api.Journey, 'function');
 		assert.equal(typeof api.JourneyResponse, 'function');
+	});
+
+	it('should re-export component questions and helpers', () => {
+		assert.equal(typeof api.AddressQuestion, 'function');
+		assert.equal(typeof api.BooleanQuestion, 'function');
+		assert.equal(typeof api.CheckboxQuestion, 'function');
+		assert.equal(typeof api.DateQuestion, 'function');
+		assert.equal(typeof api.DatePeriodQuestion, 'function');
+		assert.equal(typeof api.DateTimeQuestion, 'function');
+		assert.equal(typeof api.EmailQuestion, 'function');
+		assert.equal(typeof api.ManageListQuestion, 'function');
+		assert.equal(typeof api.MultiFieldInputQuestion, 'function');
+		assert.equal(typeof api.NumberEntryQuestion, 'function');
+		assert.equal(typeof api.RadioQuestion, 'function');
+		assert.equal(typeof api.SelectQuestion, 'function');
+		assert.equal(typeof api.SingleLineInputQuestion, 'function');
+		assert.equal(typeof api.TextEntryQuestion, 'function');
+		assert.equal(typeof api.TextEntryRedactQuestion, 'function');
+		assert.equal(typeof api.UnitOptionEntryQuestion, 'function');
+
+		assert.equal(typeof api.BOOLEAN_OPTIONS, 'object');
+		assert.equal(typeof api.yesNoToBoolean, 'function');
+		assert.equal(typeof api.booleanToYesNoValue, 'function');
+		assert.equal(typeof api.booleanToYesNoOrNull, 'function');
+		assert.equal(typeof api.REDACT_CHARACTER, 'string');
+		assert.equal(typeof api.TRUNCATED_MAX_LENGTH, 'number');
 	});
 });


### PR DESCRIPTION
This PR fixes issues where component classes could not be imported from the package in TypeScript.

All component classes now use named exports, and the main index.js file re-exports them consistently. Default exports are added for backwards compatibility.

I've deliberately omitted the Identifier question as this does not seem to be fully included in the project.

A test has been added to ensure the public API exposes all key components as intended.