### PR TITLE
fix: removes accidental private tag from jsdoc comment

### DIFF
--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -95,7 +95,7 @@ export class Question {
 	/**
 	 * Private, but not marked as such because it breaks types, either using #variable:
 	 * - Property '#isInManageListSection' is missing in type
-	 * or with @private
+	 * or with the @ private tag
 	 * - Types have separate declarations of a private property '_isInManageListSection'.
 	 * @type {boolean}
 	 */


### PR DESCRIPTION
- Encountering issue where `Types have separate declarations of a private property '_isInManageListSection'.ts(2345)`
- This was fixed before but the reference to the `@private` tag in the JSDoc comment I think was being picked up by the auto generation of declaration files as a real tag, so will still viewed as `private`