### PR TITLE
fix: swaps return paths to relative ones to fix TS errors

### DIFF
--- a/src/components/unit-option-entry/question.js
+++ b/src/components/unit-option-entry/question.js
@@ -66,8 +66,8 @@ export class UnitOptionEntryQuestion extends Question {
 	 * @param {Record<string, unknown>} [customViewData] additional data to send to view
 	 * @param {Record<string, unknown>} [payload]
 	 * @param {import('#question-types').PrepQuestionForRenderingOptions} options
-	 * @returns {import('#question').QuestionViewModel & {
-	 *   question: import('#question').QuestionViewModel['question'] & {
+	 * @returns {import('../../questions/question.js').QuestionViewModel & {
+	 *   question: import('../../questions/question.js').QuestionViewModel['question'] & {
 	 *     options:UnitOption[]
 	 *   }
 	 * }}

--- a/src/components/utils/question-has-answer.js
+++ b/src/components/utils/question-has-answer.js
@@ -20,7 +20,7 @@ export const logicalCombinations = (response) => ({
  *
  * @param {import('#question').Question} question
  * @param {unknown} expectedValue
- * @returns {import('#src/section.js').QuestionCondition}
+ * @returns {import('../../section.js').QuestionCondition}
  */
 export const whenQuestionHasAnswer = (question, expectedValue) => {
 	return (response) => questionHasAnswer(response, question, expectedValue);


### PR DESCRIPTION
- There seems to be an issue where JSDocs that use subpath imports (e.g. `#path/to/file.js`) do not get correctly picked up by TypeScript in the consuming repo and instead error.
- There are a lot of these but it has probably been missed until now because almost all of them are parameters, so you wouldn't notice it in development. E.g. `questionHasAnswer('foo', true, { random: 'thing' })` passes TS checks even though the function is supposedly typed, so you would just assume everything is fine:
```
 * @param {import('#src/journey/journey-response.js').JourneyResponse} response
 * @param {import('#question').Question|{optionJoinString: string}} question
 * @param {unknown} expectedValue
 * @returns {boolean}
 ```
 - However, a couple are used as `return` values typing, so it causes errors in our service because we do not allow unsafe arguments to be passed as parameters to other functions.
 - First solution was just to change these imports so they're relative, with this one just addressing those 2 that are return values.
 - A further ticket could be done to go around and replace every single other one