### PR TITLE
Fix/options question duplicate definition

### DIFF
--- a/src/questions/options-question.js
+++ b/src/questions/options-question.js
@@ -34,7 +34,7 @@ const defaultOptionJoinString = ',';
  * @typedef {import('./question').QuestionViewModel & { question: { options: Option[] } }} OptionsViewModel
  */
 
-export default class OptionsQuestion extends Question {
+export class OptionsQuestion extends Question {
 	/** @type {Array<Option>} */
 	options;
 
@@ -150,3 +150,5 @@ export default class OptionsQuestion extends Question {
 		return { answers };
 	}
 }
+
+export default OptionsQuestion;

--- a/src/questions/options-question.js
+++ b/src/questions/options-question.js
@@ -33,14 +33,16 @@ const defaultOptionJoinString = ',';
 /**
  * @typedef {import('./question').QuestionViewModel & { question: { options: Option[] } }} OptionsViewModel
  */
+/**
+ * @typedef {import('#question-types').QuestionParameters & { options: Array<Option> }} OptionsQuestionParameters
+ */
 
 export class OptionsQuestion extends Question {
 	/** @type {Array<Option>} */
 	options;
 
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {Array<Option>} params.options
+	 * @param {OptionsQuestionParameters} params
 	 */
 	constructor(params) {
 		// add default valid options validator to all options questions

--- a/src/validator/valid-option-validator.js
+++ b/src/validator/valid-option-validator.js
@@ -4,10 +4,6 @@ import BaseValidator from './base-validator.js';
 import { toArray } from '#src/lib/utils.js';
 
 /**
- * @typedef {import('../questions/options-question.js')} OptionsQuestion
- */
-
-/**
  * enforces a field is within the question's predefined list of options
  * @class
  */
@@ -28,7 +24,7 @@ export class ValidOptionValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the value sent for the questionObj's fieldname is within the predefined list of options
-	 * @param {OptionsQuestion} questionObj
+	 * @param {import('../questions/options-question.js').default} questionObj
 	 */
 	validate(questionObj) {
 		return body(questionObj.fieldName)


### PR DESCRIPTION
Various type fixes around `OptionsQuestion`:

- Standardise exporting with other question classes, so that it can be imported by both JS and TS projects (backwards-compatible)
- Define `OptionsQuestionParameters` in a way that works for type export
- Remove redefinition of `OptionsQuestion` in `valid-option-validator` that was causing a type conflict