### PR TITLE
fix(types): correct imports for journey types

### DIFF
--- a/move-types.js
+++ b/move-types.js
@@ -1,14 +1,12 @@
 import { copyFile } from 'node:fs/promises';
 import path from 'path';
 
-async function copyAndOverwrite(src, dest) {
+const filesToCopy = ['questions/question-props.d.ts', 'questions/question-types.d.ts', 'journey/journey-types.d.ts'];
+
+// copy some of the type definition files to the types output that are not automatically included
+for (const file of filesToCopy) {
+	const src = path.join(import.meta.dirname, 'src', file);
+	const dest = path.join(import.meta.dirname, 'types', 'src', file);
 	await copyFile(src, dest);
 	console.log(`Copied ${src} to ${dest}`);
 }
-
-const srcDir = path.join(import.meta.dirname, 'src', 'questions');
-const typesDir = path.join(import.meta.dirname, 'types', 'src', 'questions');
-
-// copy some of the type definition files to the types output that are not automatically included
-copyAndOverwrite(path.join(srcDir, 'question-props.d.ts'), path.join(typesDir, 'question-props.d.ts'));
-copyAndOverwrite(path.join(srcDir, 'question-types.d.ts'), path.join(typesDir, 'question-types.d.ts'));

--- a/src/components/manage-list/utils.js
+++ b/src/components/manage-list/utils.js
@@ -1,6 +1,6 @@
 /**
  *
- * @param {import('#src/journey/journey-response.js').JourneyResponse} response
+ * @param {import('../../journey/journey-response.js').JourneyResponse} response
  * @param {import('./question.js')} manageListQuestion
  * @param {string} manageListItemId
  * @returns {Record<string, unknown>}
@@ -16,10 +16,10 @@ export function answerObjectForManageList(response, manageListQuestion, manageLi
 /**
  * Similar to answerObjectForManageList but will edit response and add a new array entry if not found
  *
- * @param {import('#src/journey/journey-response.js').JourneyResponse} response
+ * @param {import('../../journey/journey-response.js').JourneyResponse} response
  * @param {import('./question.js')} manageListQuestion
- * @param {import('#src/journey/journey-types.d.ts').RouteParams} params
- * @returns {import('#src/journey/journey-types.d.ts').ManageListAnswers}
+ * @param {import('../../journey/journey-types.js').RouteParams} params
+ * @returns {import('../../journey/journey-types.js').ManageListAnswers}
  */
 export function answerObjectForManageListSaving(response, manageListQuestion, params) {
 	const answersList =

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export * from './controller.js';
 // Journey
 export { Journey } from './journey/journey.js';
 export { JourneyResponse } from './journey/journey-response.js';
+export * from './journey/journey-types.js';
 
 // lib
 export * from './lib/address.js';

--- a/src/journey/journey-response.js
+++ b/src/journey/journey-response.js
@@ -18,7 +18,7 @@ export class JourneyResponse {
 	journeyId;
 
 	/**
-	 * @type {import('./journey-types.d.ts').JourneyAnswers} - answers to the journey
+	 * @type {import('./journey-types.js').JourneyAnswers} - answers to the journey
 	 */
 	answers;
 
@@ -26,7 +26,7 @@ export class JourneyResponse {
 	 * creates an instance of a JourneyResponse
 	 * @param {JourneyType} journeyId
 	 * @param {string} referenceId
-	 * @param {import('./journey-types.d.ts').JourneyAnswers | null} answers
+	 * @param {import('./journey-types.js').JourneyAnswers | null} answers
 	 * @param {string} [lpaCode]
 	 */
 	constructor(journeyId, referenceId, answers, lpaCode) {

--- a/src/journey/journey-types.js
+++ b/src/journey/journey-types.js
@@ -1,0 +1,1 @@
+// empty source file to go with .d.ts file

--- a/src/journey/journey.js
+++ b/src/journey/journey.js
@@ -7,25 +7,19 @@ import { END_OF_SECTION } from '#src/section.js';
 import { MANAGE_LIST_ACTIONS } from '#src/components/manage-list/manage-list-actions.js';
 
 /**
- * @typedef {import('./journey-response').JourneyResponse} JourneyResponse
- * @typedef {import('../section').Section} Section
- * @typedef {import('../questions/question').Question} Question
- */
-
-/**
  * A journey (An entire set of questions required for a completion of a submission)
  * @class
  */
 export class Journey {
 	/** @type {string} journeyId - a unique, human-readable id for this journey */
 	journeyId;
-	/** @type {Array.<Section>} sections - sections within the journey */
+	/** @type {Array.<import('../section.js').Section>} sections - sections within the journey */
 	sections = [];
-	/** @type {JourneyResponse} response - the user's response to the journey so far */
+	/** @type {import('./journey-response.js').JourneyResponse} response - the user's response to the journey so far */
 	response;
 	/** @type {string} baseUrl - base url of the journey, gets prepended to question urls */
 	baseUrl = '';
-	/** @type {(journeyResponse: JourneyResponse) => string} baseUrl - base url of the journey, gets prepended to question urls */
+	/** @type {(journeyResponse: import('./journey-response.js').JourneyResponse) => string} makeBaseUrl - function to generate base url of the journey */
 	makeBaseUrl = () => '';
 	/** @type {string} taskListUrl - url that renders the task list */
 	taskListUrl = '';
@@ -44,15 +38,15 @@ export class Journey {
 	 * creates an instance of a journey
 	 * @param {object} options
 	 * @param {string} options.journeyId - a unique, human-readable id for this journey
-	 * @param {(response: JourneyResponse) => string} options.makeBaseUrl - base url of journey
+	 * @param {(response: import('./journey-response.js').JourneyResponse) => string} options.makeBaseUrl - base url of journey
 	 * @param {string} [options.taskListUrl] - task list url - added to base url, can be left undefined
-	 * @param {JourneyResponse} options.response - user's response
+	 * @param {import('./journey-response.js').JourneyResponse} options.response - user's response
 	 * @param {string} options.journeyTemplate - template used for all views
 	 * @param {string} options.taskListTemplate - path to njk view for listing page
 	 * @param {string} [options.informationPageViewPath] - path to njk view for pdf summary page
 	 * @param {string} options.journeyTitle - part of the title in the njk view
 	 * @param {boolean} [options.returnToListing] - defines how the next/previous question handles end of sections
-	 * @param {Section[]} options.sections
+	 * @param {import('../section.js').Section[]} options.sections
 	 * @param {string} [options.initialBackLink] - back link when on the first question
 	 */
 	constructor({
@@ -137,7 +131,7 @@ export class Journey {
 
 	/**
 	 * utility function to build up a url to a question
-	 * @param {import('./journey-types.d.ts').RouteParams} params
+	 * @param {import('./journey-types.js').RouteParams} params
 	 * @returns {string} url for a question
 	 */
 	#buildQuestionUrl(params) {
@@ -151,7 +145,7 @@ export class Journey {
 	/**
 	 * Gets section based on segment
 	 * @param {string} sectionSegment
-	 * @returns {Section | undefined}
+	 * @returns {import('../section.js').Section | undefined}
 	 */
 	getSection(sectionSegment) {
 		return this.sections.find((s) => {
@@ -161,10 +155,10 @@ export class Journey {
 
 	/**
 	 * Get question within a section
-	 * @param {Section} section
+	 * @param {import('../section.js').Section} section
 	 * @param {string} questionSegment
 	 * @param {{action: string, itemId: string, question: string}} [manageListParams]
-	 * @returns {Question | undefined} question if it belongs in the given section
+	 * @returns {import('../questions/question.js').Question | undefined} question if it belongs in the given section
 	 */
 	#getQuestion(section, questionSegment, manageListParams) {
 		const matchQuestion = (q, toMatch) => {
@@ -189,8 +183,8 @@ export class Journey {
 
 	/**
 	 * gets a question from the object's sections based on a section + question names
-	 * @param {import('./journey-types.d.ts').RouteParams} params
-	 * @returns {Question | undefined} question found by lookup
+	 * @param {import('./journey-types.js').RouteParams} params
+	 * @returns {import('../questions/question.js').Question | undefined} question found by lookup
 	 */
 	getQuestionByParams(params) {
 		const section = this.getSection(params.section);
@@ -213,7 +207,7 @@ export class Journey {
 	 * Get the back link for the journey - e.g. the previous question
 	 *
 	 * @param {Object} options
-	 * @param {import('./journey-types.d.ts').RouteParams} options.params
+	 * @param {import('./journey-types.js').RouteParams} options.params
 	 * @param {import('#src/components/manage-list/question.js')} [options.manageListQuestion]
 	 * @returns {string|null} url for the next question, or null if unmatched
 	 */
@@ -233,7 +227,7 @@ export class Journey {
 	 * Used after question post/saving
 	 *
 	 * @param {import('express').Response} res
-	 * @param {import('./journey-types.d.ts').RouteParams} params
+	 * @param {import('./journey-types.js').RouteParams} params
 	 * @param {import('#src/components/manage-list/question.js')} [manageListQuestion]
 	 * @returns {void}
 	 */
@@ -245,7 +239,7 @@ export class Journey {
 	/**
 	 * Get url for the next question in the journey
 	 *
-	 * @param {import('./journey-types.d.ts').RouteParams} params
+	 * @param {import('./journey-types.js').RouteParams} params
 	 * @param {Object} options
 	 * @param {boolean} [options.reverse] - if passed in this will get the previous question
 	 * @param {import('#src/components/manage-list/question.js')} [options.manageListQuestion]
@@ -299,7 +293,7 @@ export class Journey {
 					 * don't include other params which may be set (e.g. manageList* params), as we may now be
 					 * redirecting to a non-manage list question, having previously been on a manage list question
 					 *
-					 * @type {import('./journey-types.d.ts').RouteParams}
+					 * @type {import('./journey-types.js').RouteParams}
 					 */
 					let newParams = {
 						section: currentSection.segment,
@@ -399,7 +393,7 @@ export class Journey {
 	}
 
 	/**
-	 * @param {JourneyResponse} journeyResponse
+	 * @param {import('./journey-response.js').JourneyResponse} journeyResponse
 	 */
 	setResponse(journeyResponse) {
 		this.response = journeyResponse;

--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -7,9 +7,6 @@ import { answerObjectForManageList } from '#src/components/manage-list/utils.js'
 
 /**
  * @import {BaseValidator} from "#base-validator"
- * @import {Journey} from "#journey"
- * @import {JourneyResponse} from "#journey-response"
- * @import {Section} from "#section"
  * @import {ActionView} from "../controller.js"
  * @import {ActionLink} from "./question-types.js"
  */
@@ -83,7 +80,7 @@ export class Question {
 	addActionText = 'Add';
 
 	/**
-	 * @param {JourneyResponse} [response]
+	 * @param {import('../journey/journey-response.js').JourneyResponse} [response]
 	 * @returns {boolean}
 	 */
 	shouldDisplay = () => true;
@@ -193,10 +190,10 @@ export class Question {
 	 * that prepQuestionForRendering doesn't need
 	 *
 	 * @param {Object} options
-	 * @param {import('#src/journey/journey-types.d.ts').RouteParams} options.params
-	 * @param {import('#src/components/manage-list/question.js')} [options.manageListQuestion]
-	 * @param {Section} options.section - the current section
-	 * @param {Journey} options.journey - the journey we are in
+	 * @param {import('../journey/journey-types.js').RouteParams} options.params
+	 * @param {import('../components/manage-list/question.js')} [options.manageListQuestion]
+	 * @param {import('../section.js').Section} options.section - the current section
+	 * @param {import('../journey/journey.js').Journey} options.journey - the journey we are in
 	 * @param {Record<string, unknown>} [options.customViewData] additional data to send to view
 	 * @param {unknown} [options.payload]
 	 * @returns {QuestionViewModel}
@@ -213,8 +210,8 @@ export class Question {
 	/**
 	 * gets the base view model for this question
 	 *
-	 * @param {Section} section - the current section
-	 * @param {Journey} journey - the journey we are in
+	 * @param {import('../section.js').Section} section - the current section
+	 * @param {import('../journey/journey.js').Journey} journey - the journey we are in
 	 * @param {Record<string, unknown>} [customViewData] additional data to send to view
 	 * @param {unknown} [payload]
 	 * @param {import('#question-types').PrepQuestionForRenderingOptions} [options] - required to support manage list question
@@ -284,7 +281,7 @@ export class Question {
 	/**
 	 * Get the answers object from the journey response, which may be nested in an array for manage list questions
 	 *
-	 * @param {JourneyResponse} response
+	 * @param {import('../journey/journey-response.js').JourneyResponse} response
 	 * @param {import('#question-types').PrepQuestionForRenderingOptions} [options]
 	 * @returns {Record<string, any>}
 	 */
@@ -320,9 +317,9 @@ export class Question {
 	/**
 	 * check for validation errors
 	 * @param {import('express').Request} req
-	 * @param {Journey} journey
-	 * @param {Section} section
-	 * @param {import('#src/components/manage-list/question.js')} [manageListQuestion]
+	 * @param {import('../journey/journey.js').Journey} journey
+	 * @param {import('../section.js').Section} section
+	 * @param {import('../components/manage-list/question.js')} [manageListQuestion]
 	 * @returns {QuestionViewModel|undefined} returns the view model for displaying the error or undefined if there are no errors
 	 */
 	checkForValidationErrors(req, section, journey, manageListQuestion) {
@@ -348,7 +345,7 @@ export class Question {
 	 * Get the data to save from the request, returns an object of answers
 	 *
 	 * @param {import('express').Request} req
-	 * @param {JourneyResponse} journeyResponse - current journey response
+	 * @param {import('../journey/journey-response.js').JourneyResponse} journeyResponse - current journey response
 	 * @returns {Promise<{ answers: Record<string, unknown> }>}
 	 */ //eslint-disable-next-line no-unused-vars -- journeyResponse kept for other questions to use
 	async getDataToSave(req, journeyResponse) {
@@ -368,8 +365,8 @@ export class Question {
 	/**
 	 * check for errors after saving, by default this does nothing
 	 * @param {import('express').Request} req
-	 * @param {Journey} journey
-	 * @param {Section} sectionObj
+	 * @param {import('../journey/journey.js').Journey} journey
+	 * @param {import('../section.js').Section} sectionObj
 	 * @returns {QuestionViewModel | undefined} returns the view model for displaying the error or undefined if there are no errors
 	 */ //eslint-disable-next-line no-unused-vars
 	checkForSavingErrors(req, sectionObj, journey) {
@@ -380,7 +377,7 @@ export class Question {
 	 * Handles redirect after saving. Kept around for backwards compatibility.
 	 *
 	 * @param {import('express').Response} res
-	 * @param {Journey} journey
+	 * @param {import('../journey/journey.js').Journey} journey
 	 * @param {string} sectionSegment
 	 * @param {string} questionSegment
 	 * @returns {void}
@@ -396,7 +393,7 @@ export class Question {
 	/**
 	 * returns the formatted answers values to be used to build task list elements
 	 * @param {String} sectionSegment
-	 * @param {Journey} journey
+	 * @param {import('../journey/journey.js').Journey} journey
 	 * @param {Object} answer
 	 * @returns {Array<{
 	 *   key: string;
@@ -420,7 +417,7 @@ export class Question {
 	/**
 	 * Returns the action link for the question
 	 * @param {Object} answer
-	 * @param {Journey} journey
+	 * @param {import('../journey/journey.js').Journey} journey
 	 * @param {String} sectionSegment
 	 * @returns {ActionView|ActionView[]|undefined}
 	 */
@@ -475,7 +472,7 @@ export class Question {
 	}
 
 	/**
-	 * @param {JourneyResponse} journeyResponse
+	 * @param {import('../journey/journey-response.js').JourneyResponse} journeyResponse
 	 * @param {string} [fieldName] optional fieldname for multi field input questions
 	 * @returns {boolean}
 	 */


### PR DESCRIPTION
- Refactor `move-types` to easily accept more files, and add `journey-types.d.ts` to it, so that these types are included in the release
- Add `journey-types.js` placeholder and change imports so that the JSDoc conversion properly understands the journey types file
- Add `journey-types` export to project index
- Fix some types so that imports are used inline instead of being redefined at the top of the file, which causes issues with the generated types
- Remove some relative paths, which do not work with the generated types