### PR TITLE
Fix/question type fixes

### DIFF
--- a/src/components/boolean/question.js
+++ b/src/components/boolean/question.js
@@ -103,7 +103,7 @@ export class BooleanQuestion extends RadioQuestion {
 	 * Get the data to save from the request, returns an object of answers
 	 * @param {import('express').Request} req
 	 * @param {JourneyResponse} journeyResponse - current journey response, modified with the new answers
-	 * @returns {Promise.<Object>}
+	 * @returns {Promise<{ answers: Record<string, unknown> }>}
 	 */ //eslint-disable-next-line no-unused-vars -- journeyResponse kept for other questions to use
 	async getDataToSave(req, journeyResponse) {
 		const answers = {};

--- a/src/components/radio/question.js
+++ b/src/components/radio/question.js
@@ -72,7 +72,7 @@ export class RadioQuestion extends OptionsQuestion {
 	 * @param {Object} answer
 	 * @param {Journey} journey
 	 * @param {String} sectionSegment
-	 * @returns {Array.<Object>}
+	 * @returns {Array<{ key: string; value: string | Object; action?: ActionView | ActionView[] | undefined; }>}
 	 */
 	formatAnswerForSummary(sectionSegment, journey, answer) {
 		if (answer?.conditional) {

--- a/src/questions/create-questions.js
+++ b/src/questions/create-questions.js
@@ -2,7 +2,7 @@
 
 /**
  * @param {{[questionName: string]: QuestionProps}} questionPropsRecord
- * @param {Record<string, typeof import('./question').Question>} questionClasses
+ * @param {Record<string, import('./question-types.js').QuestionClass>} questionClasses
  * @param {{[questionType: string]: Record<string, Function>}} questionMethodOverrides
  * @param {{notStartedText?: string, continueButtonText?: string, changeActionText?: string, answerActionText?: string}} [textOverrides] - customise question text
  */

--- a/src/questions/question-types.d.ts
+++ b/src/questions/question-types.d.ts
@@ -78,3 +78,9 @@ export interface PrepQuestionForRenderingOptions {
 	params: RouteParams;
 	manageListQuestion?: ManageListQuestion;
 }
+
+/**
+ * Define a question class type so that projects downstream can extend the
+ * Question class and still pass them to the createQuestions function.
+ */
+export type QuestionClass<TQuestion extends Question = Question> = new (...args: never[]) => TQuestion;


### PR DESCRIPTION
- Fix return type on some question methods so they match the return types of the parent classes
- Add `QuestionClass` type that allows for `createQuestions` to accept custom questions that have been extended from the base `Question` class