### PR TITLE
fix(types): update answer parameter type to unknown

### DIFF
--- a/src/components/number-entry/question.js
+++ b/src/components/number-entry/question.js
@@ -31,7 +31,7 @@ export class NumberEntryQuestion extends Question {
 
 	/**
 	 * returns the formatted answers values to be used to build task list elements
-	 * @param {Object} answer
+	 * @param {unknown} answer
 	 * @param {import('#journey').Journey} journey
 	 * @param {String} sectionSegment
 	 * @returns {Array<{

--- a/src/components/radio/question.js
+++ b/src/components/radio/question.js
@@ -69,7 +69,7 @@ export class RadioQuestion extends OptionsQuestion {
 
 	/**
 	 * returns the formatted answers values to be used to build task list elements
-	 * @param {Object} answer
+	 * @param {unknown} answer
 	 * @param {Journey} journey
 	 * @param {String} sectionSegment
 	 * @returns {Array<{ key: string; value: string | Object; action?: ActionView | ActionView[] | undefined; }>}

--- a/src/components/select/question.js
+++ b/src/components/select/question.js
@@ -70,7 +70,7 @@ export class SelectQuestion extends OptionsQuestion {
 	 * returns the formatted answers values to be used to build task list elements
 	 * note: only supports a single answer
 	 *
-	 * @param {Object} answer
+	 * @param {unknown} answer
 	 * @param {Journey} journey
 	 * @param {String} sectionSegment
 	 * @returns {Array.<Object>}

--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -394,7 +394,7 @@ export class Question {
 	 * returns the formatted answers values to be used to build task list elements
 	 * @param {String} sectionSegment
 	 * @param {import('../journey/journey.js').Journey} journey
-	 * @param {Object} answer
+	 * @param {unknown} answer
 	 * @returns {Array<{
 	 *   key: string;
 	 *   value: string | Object;
@@ -416,7 +416,7 @@ export class Question {
 
 	/**
 	 * Returns the action link for the question
-	 * @param {Object} answer
+	 * @param {unknown} answer
 	 * @param {import('../journey/journey.js').Journey} journey
 	 * @param {String} sectionSegment
 	 * @returns {ActionView|ActionView[]|undefined}


### PR DESCRIPTION
The `answer` parameter in various questions was typed as `object`, which isn't correct - answers coming from the journey are unknown at this stage (as typed in `JourneyAnswers`)