### PR TITLE
fix: swaps more subpaths in section and question for relative ones

### DIFF
--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -99,7 +99,7 @@ export class Question {
 	_isInManageListSection = false;
 
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
+	 * @param {import('./question-types.js').QuestionParameters} params
 	 * @param {Record<string, Function>} [methodOverrides]
 	 */
 	constructor(
@@ -214,7 +214,7 @@ export class Question {
 	 * @param {import('../journey/journey.js').Journey} journey - the journey we are in
 	 * @param {Record<string, unknown>} [customViewData] additional data to send to view
 	 * @param {unknown} [payload]
-	 * @param {import('#question-types').PrepQuestionForRenderingOptions} [options] - required to support manage list question
+	 * @param {import('./question-types.js').PrepQuestionForRenderingOptions} [options] - required to support manage list question
 	 * @returns {QuestionViewModel}
 	 */
 	prepQuestionForRendering(section, journey, customViewData, payload, options) {
@@ -282,7 +282,7 @@ export class Question {
 	 * Get the answers object from the journey response, which may be nested in an array for manage list questions
 	 *
 	 * @param {import('../journey/journey-response.js').JourneyResponse} response
-	 * @param {import('#question-types').PrepQuestionForRenderingOptions} [options]
+	 * @param {import('./question-types.js').PrepQuestionForRenderingOptions} [options]
 	 * @returns {Record<string, any>}
 	 */
 	answerObjectFromJourneyResponse(response, { params, manageListQuestion } = {}) {

--- a/src/section.js
+++ b/src/section.js
@@ -83,8 +83,8 @@ export class Section {
 
 	/**
 	 * Fluent API method for adding questions
-	 * @param {import('#src/questions/question.js').Question} question
-	 * @param {import('#src/components/manage-list/manage-list-section.js').ManageListSection} [manageListSection]
+	 * @param {import('./questions/question.js').Question} question
+	 * @param {import('./components/manage-list/manage-list-section.js').ManageListSection} [manageListSection]
 	 * @returns {Section}
 	 */
 	addQuestion(question, manageListSection) {


### PR DESCRIPTION
- Removes more subpaths in JSDocs, specific focus on the subpaths in `section.js` and `questions/question.js`
- Purposefully doing this piece by piece, as and when issues are hit, as this can introduce previously hidden type issues.