### PR TITLE
fix(types): make question props extensible

### DIFF
--- a/src/questions/create-questions.js
+++ b/src/questions/create-questions.js
@@ -1,10 +1,10 @@
-/** @typedef {import('./question-props').QuestionProps} QuestionProps */
-
 /**
- * @param {{[questionName: string]: QuestionProps}} questionPropsRecord
+ * @template {import('./question-props.js').BaseQuestionProps} T
+ * @param {{[questionName: string]: T}} questionPropsRecord
  * @param {Record<string, import('./question-types.js').QuestionClass>} questionClasses
  * @param {{[questionType: string]: Record<string, Function>}} questionMethodOverrides
  * @param {{notStartedText?: string, continueButtonText?: string, changeActionText?: string, answerActionText?: string}} [textOverrides] - customise question text
+ * @returns {Record<string, InstanceType<import('./question-types.js').QuestionClass>>}
  */
 export function createQuestions(questionPropsRecord, questionClasses, questionMethodOverrides, textOverrides) {
 	return Object.fromEntries(

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -22,6 +22,13 @@ type CommonQuestionProps = Omit<QuestionParameters, 'viewFolder'> & {
 	type: QuestionTypes;
 };
 
+/**
+ * Generic question props type so that custom components can be used without having to define a new type for each one.
+ */
+export type BaseQuestionProps = Omit<CommonQuestionProps, 'type'> & {
+	type: string;
+};
+
 type Option =
 	| {
 			text: string;


### PR DESCRIPTION
the `questionPropsRecord` param type was broken and reverting to `any`. fixing this highlighted that using `QuestionProps` for it limits usage to only core dynamic-forms questions; instead we need to use a definition that allows for questions that extend the core question properties, and can have any `type` property.

also adds return type for `createQuestions`