### PR TITLE
fix: return types for sections swapped for more accurate this

### DIFF
--- a/src/components/manage-list/manage-list-section.js
+++ b/src/components/manage-list/manage-list-section.js
@@ -23,7 +23,7 @@ export class ManageListSection extends Section {
 	 * Fluent API method for adding questions
 	 * @param {import('../../questions/question.js').Question} question
 	 * @param {import('./manage-list-section.js').ManageListSection} [manageListSection]
-	 * @returns {import('../../section.js').Section}
+	 * @returns {this}
 	 */
 	addQuestion(question, manageListSection) {
 		if (!question) {

--- a/src/section.js
+++ b/src/section.js
@@ -85,7 +85,7 @@ export class Section {
 	 * Fluent API method for adding questions
 	 * @param {import('./questions/question.js').Question} question
 	 * @param {import('./components/manage-list/manage-list-section.js').ManageListSection} [manageListSection]
-	 * @returns {Section}
+	 * @returns {this}
 	 */
 	addQuestion(question, manageListSection) {
 		if (!question) {


### PR DESCRIPTION
- Return types for `ManageListSection` and `Section` were slightly wrong and caused errors in consuming repo