### PR TITLE
fix: add error summary display on redaction page

### DIFF
--- a/src/components/text-entry-redact/index.njk
+++ b/src/components/text-entry-redact/index.njk
@@ -102,7 +102,7 @@
                     },
                     classes: question.inputClasses,
                     attributes: {
-                        readonly: true
+                        readonly: "readonly"
                     },
                     rows: textAreaRows or 8
                 }) }}
@@ -152,14 +152,59 @@
 
             const history = [];
             function showError(message) {
+              // Show inline error
               formGroup.classList.add('govuk-form-group--error');
-              errorMessage.textContent = message;
+              errorMessage.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${message}`;
               formGroup.prepend(errorMessage);
-            }
-            function hideError() {
-              textArea.parentElement.classList.remove('govuk-form-group--error');
-              errorMessage.remove();
-            }
+
+							// show error summary
+							let errorSummary = document.querySelector('.govuk-error-summary');
+							if (!errorSummary) {
+								const summaryContainer = document.createElement('div');
+								summaryContainer.className = 'govuk-grid-row';
+								summaryContainer.innerHTML =`
+                                  <div class="govuk-grid-column-two-thirds">
+                                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                                      <h2 class="govuk-error-summary__title" id="error-summary-title">
+                                      There is a problem
+                                      </h2>
+                                      <div class="govuk-error-summary__body">
+                                        <ul class="govuk-list govuk-error-summary__list"></ul>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  `;
+
+								const mainContainer = document.querySelector('.govuk-grid-row');
+								if (mainContainer && mainContainer.parentNode) {
+									mainContainer.parentNode.insertBefore(summaryContainer, mainContainer);
+								}
+								errorSummary = summaryContainer.querySelector('.govuk-error-summary');
+							}
+
+							// Update error list
+							const errorList = errorSummary.querySelector('.govuk-error-summary__list');
+							errorList.innerHTML = `<li><a href="#{{ question.fieldName }}">${message}</a></li>`;
+							errorSummary.focus();
+						}
+
+						function hideError() {
+							// Remove inline error
+							formGroup.classList.remove('govuk-form-group--error');
+							if (errorMessage.parentNode) {
+								errorMessage.remove();
+							}
+
+							// Remove error summary
+							const errorSummary = document.querySelector('.govuk-error-summary');
+							if (errorSummary) {
+								const summaryContainer = errorSummary.closest('.govuk-grid-row');
+								if (summaryContainer) {
+									summaryContainer.remove();
+								}
+							}
+						}
+
             redactSelectedText.addEventListener('click', () => {
               const { selectionStart, selectionEnd } = textArea;
               if (selectionStart === selectionEnd) {

--- a/test/snapshots/secret-wish.html
+++ b/test/snapshots/secret-wish.html
@@ -29,7 +29,7 @@
   <label class="govuk-label" for="secretWish">
     Secret wish
   </label>
-  <textarea class="govuk-textarea" id="secretWish" name="secretWish" rows="8" readonly="true"></textarea>
+  <textarea class="govuk-textarea" id="secretWish" name="secretWish" rows="8" readonly="readonly"></textarea>
 </div>
 
 
@@ -72,14 +72,59 @@
 
             const history = [];
             function showError(message) {
+              // Show inline error
               formGroup.classList.add('govuk-form-group--error');
-              errorMessage.textContent = message;
+              errorMessage.innerHTML = `<span class="govuk-visually-hidden">Error:</span> ${message}`;
               formGroup.prepend(errorMessage);
-            }
-            function hideError() {
-              textArea.parentElement.classList.remove('govuk-form-group--error');
-              errorMessage.remove();
-            }
+
+							// show error summary
+							let errorSummary = document.querySelector('.govuk-error-summary');
+							if (!errorSummary) {
+								const summaryContainer = document.createElement('div');
+								summaryContainer.className = 'govuk-grid-row';
+								summaryContainer.innerHTML =`
+                                  <div class="govuk-grid-column-two-thirds">
+                                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                                      <h2 class="govuk-error-summary__title" id="error-summary-title">
+                                      There is a problem
+                                      </h2>
+                                      <div class="govuk-error-summary__body">
+                                        <ul class="govuk-list govuk-error-summary__list"></ul>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  `;
+
+								const mainContainer = document.querySelector('.govuk-grid-row');
+								if (mainContainer && mainContainer.parentNode) {
+									mainContainer.parentNode.insertBefore(summaryContainer, mainContainer);
+								}
+								errorSummary = summaryContainer.querySelector('.govuk-error-summary');
+							}
+
+							// Update error list
+							const errorList = errorSummary.querySelector('.govuk-error-summary__list');
+							errorList.innerHTML = `<li><a href="#secretWish">${message}</a></li>`;
+							errorSummary.focus();
+						}
+
+						function hideError() {
+							// Remove inline error
+							formGroup.classList.remove('govuk-form-group--error');
+							if (errorMessage.parentNode) {
+								errorMessage.remove();
+							}
+
+							// Remove error summary
+							const errorSummary = document.querySelector('.govuk-error-summary');
+							if (errorSummary) {
+								const summaryContainer = errorSummary.closest('.govuk-grid-row');
+								if (summaryContainer) {
+									summaryContainer.remove();
+								}
+							}
+						}
+
             redactSelectedText.addEventListener('click', () => {
               const { selectionStart, selectionEnd } = textArea;
               if (selectionStart === selectionEnd) {


### PR DESCRIPTION
This pull request enhances the error handling and user feedback in the `text-entry-redact` component by improving how errors are displayed to users. The main changes are focused on providing a more accessible and visible error summary, in addition to the existing inline error messaging.

**Error handling and user feedback improvements:**

* Enhanced the `showError` function to display an error summary at the top of the page when a validation error occurs, following GOV.UK design patterns for error summaries. This includes dynamically creating and inserting the error summary if it does not already exist, updating the error list, and focusing the summary for accessibility.
* Updated the inline error message to include a visually hidden "Error:" prefix for screen readers, improving accessibility.
* Modified the `hideError` function to remove the error summary from the DOM when errors are cleared, ensuring the UI remains clean and accurate.

Fixes a bug related to crown development where the error summary was not displaying on errors when a comment was being redacted.

Jira ticket - https://pins-ds.atlassian.net/browse/CROWN-899

<img width="909" height="1016" alt="image" src="https://github.com/user-attachments/assets/939c955b-b4e5-4481-8cfe-1f92c652387d" />
