### PR TITLE
feat: adds an optional flag to date validator

### DIFF
--- a/src/validator/date-validator.js
+++ b/src/validator/date-validator.js
@@ -1,5 +1,4 @@
 import { body } from 'express-validator';
-
 import { isAfter, isBefore, isValid, parse } from 'date-fns';
 import { enGB } from 'date-fns/locale';
 
@@ -12,8 +11,9 @@ import { endOfDay, parseDateInput, startOfDay } from '../lib/date-utils.js';
 
 /**
  * @typedef {Object} DateValidationSettings
- * @property {Boolean} ensureFuture
- * @property {Boolean} ensurePast
+ * @property {Boolean} [ensureFuture]
+ * @property {Boolean} [ensurePast]
+ * @property {Boolean} [optional]
  */
 
 /**
@@ -34,7 +34,8 @@ export class DateValidator extends BaseValidator {
 		inputLabel,
 		dateValidationSettings = {
 			ensureFuture: false,
-			ensurePast: false
+			ensurePast: false,
+			optional: false
 		},
 		errorMessages
 	) {
@@ -63,7 +64,7 @@ export class DateValidator extends BaseValidator {
 	}
 
 	isRequired() {
-		return true;
+		return !this.dateValidationSettings.optional;
 	}
 
 	/**
@@ -76,9 +77,21 @@ export class DateValidator extends BaseValidator {
 		const monthInput = `${fieldName}_month`;
 		const yearInput = `${fieldName}_year`;
 
+		/**
+		 * Run before every check, if the correct param set then skip the validation
+		 * when there is no data entered.
+		 */
+		const shouldValidate = (value, { req }) => {
+			if (this.dateValidationSettings.optional === true) {
+				return !!(req.body[dayInput] || req.body[monthInput] || req.body[yearInput]);
+			}
+			return true;
+		};
+
 		const rules = [
 			// check all or some date inputs are not empty
 			body(dayInput)
+				.if(shouldValidate)
 				.notEmpty()
 				.withMessage((_, { req }) => {
 					if (!req.body[monthInput] && !req.body[yearInput]) {
@@ -96,6 +109,7 @@ export class DateValidator extends BaseValidator {
 					return this.noDayErrorMessage;
 				}),
 			body(monthInput)
+				.if(shouldValidate)
 				.notEmpty()
 				.withMessage((_, { req }) => {
 					if (req.body[dayInput] && !req.body[yearInput]) {
@@ -108,6 +122,7 @@ export class DateValidator extends BaseValidator {
 					// empty error message returned
 				}),
 			body(yearInput)
+				.if(shouldValidate)
 				.notEmpty()
 				.withMessage((_, { req }) => {
 					if (req.body[dayInput] && req.body[monthInput]) return this.noYearErrorMessage;
@@ -117,6 +132,7 @@ export class DateValidator extends BaseValidator {
 
 			// check date values entered are within valid ranges
 			body(dayInput)
+				.if(shouldValidate)
 				.isInt({ min: 1, max: 31 })
 				.withMessage(this.invalidDateErrorMessage)
 				.bail()
@@ -135,38 +151,42 @@ export class DateValidator extends BaseValidator {
 
 					return true;
 				}),
-			body(monthInput).isInt({ min: 1, max: 12 }).withMessage(this.invalidMonthErrorMessage),
-			body(yearInput).isInt({ min: 1000, max: 9999 }).withMessage(this.invalidYearErrorMessage)
+			body(monthInput).if(shouldValidate).isInt({ min: 1, max: 12 }).withMessage(this.invalidMonthErrorMessage),
+			body(yearInput).if(shouldValidate).isInt({ min: 1000, max: 9999 }).withMessage(this.invalidYearErrorMessage)
 		];
 
 		if (this.dateValidationSettings.ensurePast === true) {
 			rules.push(
-				body(dayInput).custom((value, { req }) => {
-					const inputDate = parseDateInput({ day: value, month: req.body[monthInput], year: req.body[yearInput] });
+				body(dayInput)
+					.if(shouldValidate)
+					.custom((value, { req }) => {
+						const inputDate = parseDateInput({ day: value, month: req.body[monthInput], year: req.body[yearInput] });
 
-					const today = endOfDay();
+						const today = endOfDay();
 
-					if (isAfter(inputDate, today)) {
-						throw new Error(this.futureDateErrorMessage);
-					}
+						if (isAfter(inputDate, today)) {
+							throw new Error(this.futureDateErrorMessage);
+						}
 
-					return true;
-				})
+						return true;
+					})
 			);
 		}
 
 		if (this.dateValidationSettings.ensureFuture === true) {
 			rules.push(
-				body(dayInput).custom((value, { req }) => {
-					const inputDate = parseDateInput({ day: value, month: req.body[monthInput], year: req.body[yearInput] });
-					const today = startOfDay();
+				body(dayInput)
+					.if(shouldValidate)
+					.custom((value, { req }) => {
+						const inputDate = parseDateInput({ day: value, month: req.body[monthInput], year: req.body[yearInput] });
+						const today = startOfDay();
 
-					if (isBefore(inputDate, today)) {
-						throw new Error(this.pastDateErrorMessage);
-					}
+						if (isBefore(inputDate, today)) {
+							throw new Error(this.pastDateErrorMessage);
+						}
 
-					return true;
-				})
+						return true;
+					})
 			);
 		}
 

--- a/src/validator/date-validator.test.js
+++ b/src/validator/date-validator.test.js
@@ -389,6 +389,109 @@ describe('./src/dynamic-forms/validator/date-validator.js', () => {
 			assert.strictEqual(errors[`${question.fieldName}_month`].msg, errorMessages.invalidMonthErrorMessage);
 			assert.strictEqual(errors[`${question.fieldName}_year`].msg, errorMessages.invalidYearErrorMessage);
 		});
+
+		it('passes validation if optional is true and no fields are provided (undefined)', async () => {
+			const req = {
+				body: {
+					['date-question_day']: undefined,
+					['date-question_month']: undefined,
+					['date-question_year']: undefined
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date', undefined, {
+				optional: true
+			});
+
+			assert.strictEqual(Object.keys(errors).length, 0);
+		});
+
+		it('passes validation if optional is true and fields are empty strings', async () => {
+			const req = {
+				body: {
+					['date-question_day']: '',
+					['date-question_month']: '',
+					['date-question_year']: ''
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date', undefined, {
+				optional: true
+			});
+
+			assert.strictEqual(Object.keys(errors).length, 0);
+		});
+
+		it('throws error if optional is true but date is partially filled (missing day)', async () => {
+			const req = {
+				body: {
+					['date-question_day']: '',
+					['date-question_month']: '10',
+					['date-question_year']: '2023'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date', undefined, {
+				optional: true
+			});
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_day`].msg, 'The required date must include a day');
+		});
+
+		it('throws error if optional is true but invalid values are provided', async () => {
+			const req = {
+				body: {
+					['date-question_day']: '35',
+					['date-question_month']: '10',
+					['date-question_year']: '2023'
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date', undefined, {
+				optional: true
+			});
+
+			assert.strictEqual(Object.keys(errors).length, 1);
+			assert.strictEqual(errors[`${question.fieldName}_day`].msg, 'The required date day must be a real day');
+		});
+
+		it('throws error if an object is passed without the optional key (undefined) and nothing is entered', async () => {
+			const req = {
+				body: {
+					['date-question_day']: undefined,
+					['date-question_month']: undefined,
+					['date-question_year']: undefined
+				}
+			};
+
+			const question = {
+				fieldName: 'date-question'
+			};
+
+			const errors = await _validationMappedErrors(req, question, 'the required date', undefined, {
+				randomKey: true
+			});
+
+			assert.strictEqual(Object.keys(errors).length, 3);
+			assert.strictEqual(errors[`${question.fieldName}_day`].msg, 'Enter the required date');
+		});
 	});
 });
 


### PR DESCRIPTION
- Adds the `optional` flag to the `DateValidator` that defaults to false. If true allows validators to not run if there is 0 data input, also controls the `isRequired()` function that will be set to the opposite of whatever `optional` is