### PR TITLE
feat(validator): add abstract validate method to BaseValidator

### DIFF
--- a/src/validator/base-validator.js
+++ b/src/validator/base-validator.js
@@ -13,6 +13,19 @@ export class BaseValidator {
 			throw new Error("Abstract classes can't be instantiated.");
 		}
 	}
+
+	/**
+	 * Validates response body against field validators.
+	 * Subclasses must override this method.
+	 * @abstract
+	 * @param {import('../questions/question-props.js').QuestionProps} questionObj - The question object containing the fieldName to validate.
+	 * @param {import('../journey/journey-response.js').JourneyResponse} [journeyResponse] - The current journey response (optional).
+	 * @returns {import('express-validator').ValidationChain | import('express-validator').ValidationChain[]}
+	 */
+	// eslint-disable-next-line no-unused-vars
+	validate(questionObj, journeyResponse) {
+		throw new Error('validate method must be implemented by subclass');
+	}
 }
 
 export default BaseValidator;


### PR DESCRIPTION
Add abstract `validate` method to `BaseValidator`.
I don't think this is a breaking change since validators should be implementing this anyway, but I guess it could be?