### PR TITLE
fix: align the parameter in validate for child validators to parent

### DIFF
--- a/src/validator/date-validator.js
+++ b/src/validator/date-validator.js
@@ -69,7 +69,7 @@ export class DateValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the values sent for the date are valid
-	 * @param {DateQuestion} questionObj
+	 * @param {import('../questions/question-props.js').QuestionProps} questionObj
 	 */
 	validate(questionObj) {
 		const fieldName = questionObj.fieldName;

--- a/src/validator/required-validator.js
+++ b/src/validator/required-validator.js
@@ -30,7 +30,7 @@ export class RequiredValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the questionObj's fieldname
-	 * @param {Question} questionObj
+	 * @param {import('../questions/question-props.js').QuestionProps} questionObj
 	 */
 	validate(questionObj) {
 		return body(questionObj.fieldName).notEmpty().withMessage(this.errorMessage);


### PR DESCRIPTION
- `RequiredValidator` and `DateValidator` were overriding a function in the parent class with a different typed parameter. This meant they were failing any checks which were expecting a `BaseValidator` because the types mismatched. This PR just aligns them by using the existing type