### PR TITLE
fix(types): update type definitions for validator param

### DIFF
--- a/src/validator/address-validator.js
+++ b/src/validator/address-validator.js
@@ -41,7 +41,7 @@ export class AddressValidator extends BaseValidator {
 
 	/**
 	 * validates response body using questionObj fieldname
-	 * @param {Question} questionObj
+	 * @param {import('../questions/question.js').Question} questionObj
 	 */
 	validate(questionObj) {
 		const fieldName = questionObj.fieldName;

--- a/src/validator/base-validator.js
+++ b/src/validator/base-validator.js
@@ -18,7 +18,7 @@ export class BaseValidator {
 	 * Validates response body against field validators.
 	 * Subclasses must override this method.
 	 * @abstract
-	 * @param {import('../questions/question-props.js').QuestionProps} questionObj - The question object containing the fieldName to validate.
+	 * @param {{fieldName: string}} questionObj - The question object containing the fieldName to validate.
 	 * @param {import('../journey/journey-response.js').JourneyResponse} [journeyResponse] - The current journey response (optional).
 	 * @returns {import('express-validator').ValidationChain | import('express-validator').ValidationChain[]}
 	 */

--- a/src/validator/conditional-required-validator.js
+++ b/src/validator/conditional-required-validator.js
@@ -31,7 +31,7 @@ export class ConditionalRequiredValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the questionObj's fieldname
-	 * @param {Question} questionObj
+	 * @param {import('../questions/options-question.js').OptionsQuestion} questionObj
 	 */
 	validate(questionObj) {
 		return questionObj.options.reduce((schema, option) => {

--- a/src/validator/cross-question-validator.js
+++ b/src/validator/cross-question-validator.js
@@ -37,7 +37,7 @@ export class CrossQuestionValidator extends BaseValidator {
 
 	/**
 	 * Validates response body against individual field validators.
-	 * @param {import('../questions/question-props.js').QuestionProps} questionObj - The question object containing the fieldName to validate.
+	 * @param {import('../questions/question.js').Question} questionObj - The question object containing the fieldName to validate.
 	 * @param {import('../journey/journey-response.js').JourneyResponse} [journeyResponse={}] - The current journey response, used to access saved answers for validation.
 	 * @returns {import('express-validator').ValidationChain[]}
 	 */

--- a/src/validator/date-period-validator.js
+++ b/src/validator/date-period-validator.js
@@ -7,10 +7,6 @@ import BaseValidator from './base-validator.js';
 import { parseDateInput, startOfDay } from '../lib/date-utils.js';
 
 /**
- * @typedef {import('../components/date/question.js')} DateQuestion
- */
-
-/**
  * @typedef {Object} DateValidationSettings
  * @property {Boolean} ensureFuture
  * @property {Boolean} ensurePast
@@ -64,7 +60,7 @@ export class DatePeriodValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the values sent for the date are valid
-	 * @param {DateQuestion} questionObj
+	 * @param {import('../components/date/question.js').DateQuestion} questionObj
 	 */
 	validate(questionObj) {
 		const fieldName = questionObj.fieldName;

--- a/src/validator/date-time-validator.js
+++ b/src/validator/date-time-validator.js
@@ -2,10 +2,6 @@ import { body } from 'express-validator';
 import DateValidator from './date-validator.js';
 
 /**
- * @typedef {import('./question.js')} DateTimeQuestion
- */
-
-/**
  * enforces a user has entered a valid date
  * @class
  */
@@ -32,7 +28,7 @@ export class DateTimeValidator extends DateValidator {
 
 	/**
 	 * validates the response body, checking the values sent for the date are valid
-	 * @param {DateTimeQuestion} questionObj
+	 * @param {import('../components/date-time/question.js').DateTimeQuestion} questionObj
 	 */
 	validate(questionObj) {
 		const fieldName = questionObj.fieldName;

--- a/src/validator/date-validator.js
+++ b/src/validator/date-validator.js
@@ -6,10 +6,6 @@ import BaseValidator from './base-validator.js';
 import { endOfDay, parseDateInput, startOfDay } from '../lib/date-utils.js';
 
 /**
- * @typedef {import('../components/date/question.js')} DateQuestion
- */
-
-/**
  * @typedef {Object} DateValidationSettings
  * @property {Boolean} [ensureFuture]
  * @property {Boolean} [ensurePast]
@@ -69,7 +65,7 @@ export class DateValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the values sent for the date are valid
-	 * @param {DateQuestion} questionObj
+	 * @param {import('../components/date/question.js').DateQuestion} questionObj
 	 */
 	validate(questionObj) {
 		const fieldName = questionObj.fieldName;

--- a/src/validator/required-validator.js
+++ b/src/validator/required-validator.js
@@ -3,10 +3,6 @@ import { body } from 'express-validator';
 import BaseValidator from './base-validator.js';
 
 /**
- * @typedef {import('../questions/question.js')} Question
- */
-
-/**
  * enforces a field is not empty
  * @class
  */
@@ -30,7 +26,7 @@ export class RequiredValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the questionObj's fieldname
-	 * @param {Question} questionObj
+	 * @param {import('../questions/question.js').Question} questionObj
 	 */
 	validate(questionObj) {
 		return body(questionObj.fieldName).notEmpty().withMessage(this.errorMessage);

--- a/src/validator/unit-option-entry-validator.js
+++ b/src/validator/unit-option-entry-validator.js
@@ -4,10 +4,6 @@ import BaseValidator from './base-validator.js';
 import { toArray } from '#src/lib/utils.js';
 
 /**
- * @typedef {import('../questions/question.js')} Question
- */
-
-/**
  * enforces a field is not empty when condition is satisfied
  * @class
  */
@@ -34,7 +30,7 @@ export class UnitOptionEntryValidator extends BaseValidator {
 
 	/**
 	 * validates the response body, checking the questionObj's fieldname
-	 * @param {Question} questionObj
+	 * @param {import('../components/unit-option-entry/question.js').UnitOptionEntryQuestion} questionObj
 	 */
 	validate(questionObj) {
 		return questionObj.options.reduce((schema, option) => {


### PR DESCRIPTION
Fix `questionObj` param types to reflect that this is an instance of a `Question` class and not `QuestionProps`.
On `BaseValidator` I also wanted to use `Question` as the param type, but there are ongoing issues with file path conflicts between the source files and the generated types which I could not resolve. So I have resorted to using the more generic `{fieldName: string}` for now.