### PR TITLE
feat(validator): enhance CrossQuestionValidator to support non-manage-list questions and different field types

### DIFF
--- a/src/components/address/question.js
+++ b/src/components/address/question.js
@@ -31,6 +31,20 @@ export class AddressQuestion extends Question {
 	}
 
 	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return [
+			`${this.fieldName}_addressLine1`,
+			`${this.fieldName}_addressLine2`,
+			`${this.fieldName}_townCity`,
+			`${this.fieldName}_county`,
+			`${this.fieldName}_postcode`
+		];
+	}
+
+	/**
 	 * @param {Record<string, any>} answers
 	 * @returns {*|string}
 	 */

--- a/src/components/address/question.test.js
+++ b/src/components/address/question.test.js
@@ -56,6 +56,19 @@ describe('AddressQuestion', () => {
 		return { question, mockApi, req, journeyResponse };
 	};
 
+	describe('bodyFieldNames', () => {
+		it('should return all address sub-field names', () => {
+			const { question } = setup();
+			assert.deepStrictEqual(question.bodyFieldNames, [
+				`${FIELDNAME}_addressLine1`,
+				`${FIELDNAME}_addressLine2`,
+				`${FIELDNAME}_townCity`,
+				`${FIELDNAME}_county`,
+				`${FIELDNAME}_postcode`
+			]);
+		});
+	});
+
 	describe('getDataToSave', () => {
 		it('should format the data correctly to be saved', async () => {
 			const { question, req } = setup();

--- a/src/components/date-period/question.js
+++ b/src/components/date-period/question.js
@@ -35,6 +35,21 @@ export class DatePeriodQuestion extends Question {
 	}
 
 	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return [
+			`${this.fieldName}_start_day`,
+			`${this.fieldName}_start_month`,
+			`${this.fieldName}_start_year`,
+			`${this.fieldName}_end_day`,
+			`${this.fieldName}_end_month`,
+			`${this.fieldName}_end_year`
+		];
+	}
+
+	/**
 	 * Get the data to save from the request, returns an object of answers
 	 * @param {import('express').Request} req
 	 * @param {import('#journey-response').JourneyResponse} journeyResponse - current journey response, modified with the new answers

--- a/src/components/date-period/question.test.js
+++ b/src/components/date-period/question.test.js
@@ -30,6 +30,26 @@ describe('DatePeriodQuestion', () => {
 		});
 	});
 
+	describe('bodyFieldNames', () => {
+		it('should return all start and end date field names', () => {
+			const dateQuestion = new DatePeriodQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+			assert.deepStrictEqual(dateQuestion.bodyFieldNames, [
+				`${FIELDNAME}_start_day`,
+				`${FIELDNAME}_start_month`,
+				`${FIELDNAME}_start_year`,
+				`${FIELDNAME}_end_day`,
+				`${FIELDNAME}_end_month`,
+				`${FIELDNAME}_end_year`
+			]);
+		});
+	});
+
 	describe('getDataToSave', () => {
 		it('should return data correctly', async () => {
 			const dateQuestion = new DatePeriodQuestion({

--- a/src/components/date-time/question.js
+++ b/src/components/date-time/question.js
@@ -23,6 +23,21 @@ export class DateTimeQuestion extends Question {
 	}
 
 	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return [
+			`${this.fieldName}_day`,
+			`${this.fieldName}_month`,
+			`${this.fieldName}_year`,
+			`${this.fieldName}_hour`,
+			`${this.fieldName}_minutes`,
+			`${this.fieldName}_period`
+		];
+	}
+
+	/**
 	 * Get the data to save from the request, returns an object of answers
 	 * @param {import('express').Request} req
 	 * @param {JourneyResponse} journeyResponse - current journey response, modified with the new answers

--- a/src/components/date-time/question.test.js
+++ b/src/components/date-time/question.test.js
@@ -15,6 +15,17 @@ describe('./lib/forms/custom-components/date-time/question.js', () => {
 		it('should create', () => {
 			assert.strictEqual(question.viewFolder, 'date-time');
 		});
+
+		it('should return all date and time field names from bodyFieldNames', () => {
+			assert.deepStrictEqual(question.bodyFieldNames, [
+				'siteVisitDate_day',
+				'siteVisitDate_month',
+				'siteVisitDate_year',
+				'siteVisitDate_hour',
+				'siteVisitDate_minutes',
+				'siteVisitDate_period'
+			]);
+		});
 	});
 	describe('prepQuestionForRendering', () => {
 		it('should prep question for rendering when value not in payload', () => {

--- a/src/components/date/question.js
+++ b/src/components/date/question.js
@@ -20,6 +20,14 @@ export class DateQuestion extends Question {
 	}
 
 	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return [`${this.fieldName}_day`, `${this.fieldName}_month`, `${this.fieldName}_year`];
+	}
+
+	/**
 	 * Get the data to save from the request, returns an object of answers
 	 * @param {import('express').Request} req
 	 * @param {import('#journey-response').JourneyResponse} journeyResponse - current journey response, modified with the new answers

--- a/src/components/date/question.test.js
+++ b/src/components/date/question.test.js
@@ -26,6 +26,23 @@ describe('DateQuestion', () => {
 		});
 	});
 
+	describe('bodyFieldNames', () => {
+		it('should return day, month, and year field names', () => {
+			const dateQuestion = new DateQuestion({
+				title: TITLE,
+				question: QUESTION,
+				fieldName: FIELDNAME,
+				hint: HINT,
+				validators: VALIDATORS
+			});
+			assert.deepStrictEqual(dateQuestion.bodyFieldNames, [
+				`${FIELDNAME}_day`,
+				`${FIELDNAME}_month`,
+				`${FIELDNAME}_year`
+			]);
+		});
+	});
+
 	describe('getDataToSave', () => {
 		it('should return data correctly', async () => {
 			const dateQuestion = new DateQuestion({

--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -30,6 +30,14 @@ export class MultiFieldInputQuestion extends Question {
 		}
 	}
 
+	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return this.inputFields.map((inputField) => inputField.fieldName);
+	}
+
 	answerForViewModel(answers) {
 		return this.inputFields.map((inputField) => {
 			return {

--- a/src/components/multi-field-input/question.test.js
+++ b/src/components/multi-field-input/question.test.js
@@ -51,6 +51,13 @@ describe('./src/dynamic-forms/components/multi-field-input/question.js', () => {
 		}, new Error('inputFields are mandatory'));
 	});
 
+	describe('bodyFieldNames', () => {
+		it('should return field names from all inputFields', () => {
+			const testQuestion = createMultiFieldInputQuestion();
+			assert.deepStrictEqual(testQuestion.bodyFieldNames, ['testField1', 'testField2']);
+		});
+	});
+
 	describe('prepQuestionForRendering', () => {
 		it('should call super and set inputFields', () => {
 			const question = createMultiFieldInputQuestion();

--- a/src/questions/question.js
+++ b/src/questions/question.js
@@ -182,6 +182,17 @@ export class Question {
 	}
 
 	/**
+	 * Gets the body field names used by this question in form submissions.
+	 * Returns the field names that should be present in req.body when this question is submitted.
+	 * Subclasses should override this for questions with multiple or differently-named body fields.
+	 *
+	 * @returns {string[]}
+	 */
+	get bodyFieldNames() {
+		return [this.fieldName];
+	}
+
+	/**
 	 * gets the view model for this question
 	 *
 	 * Wraps prepQuestionForRendering to add the back link - which requires more parameters

--- a/src/questions/question.test.js
+++ b/src/questions/question.test.js
@@ -135,6 +135,13 @@ describe('./src/dynamic-forms/question.js', () => {
 		});
 	});
 
+	describe('bodyFieldNames', () => {
+		it('should return an array containing the fieldName by default', () => {
+			const question = getTestQuestion();
+			assert.deepStrictEqual(question.bodyFieldNames, [FIELDNAME]);
+		});
+	});
+
 	describe('prepQuestionForRendering', () => {
 		it('should prepQuestionForRendering', () => {
 			const question = getTestQuestion();

--- a/src/validator/cross-question-validator.README.md
+++ b/src/validator/cross-question-validator.README.md
@@ -1,0 +1,131 @@
+# Cross-question validator
+
+The `CrossQuestionValidator` enables validation of a question's answer against another question's answer using a custom validation function. This is useful for scenarios where the validity of one answer depends on another answer.
+
+## Constructor options
+
+| Parameter                 | Type                                           | Default      | Description                                                                                    |
+| ------------------------- | ---------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------- |
+| `dependencyFieldName`     | `string`                                       | **required** | The field name of the other question to compare against                                        |
+| `validationFunction`      | `(currentAnswer, dependencyAnswer) => boolean` | **required** | Function that returns `true` if valid, or throws an `Error` with a specific message if invalid |
+| `useBodyValues`           | `boolean`                                      | `false`      | Use `req.body` values for **both** current and dependency answers                              |
+| `useBodyValuesForCurrent` | `boolean`                                      | `false`      | Use `req.body` value for current answer only (dependency still uses JourneyResponse)           |
+
+## Use cases
+
+### 1. Validation between separate manage list questions (JourneyResponse data)
+
+When validating between questions where both answers are already saved to the JourneyResponse (e.g., in a manage list journey), use the default settings.
+
+```js
+import { CrossQuestionValidator } from '@planning-inspectorate/dynamic-forms';
+
+const startDateQuestion = {
+	type: COMPONENT_TYPES.DATE,
+	fieldName: 'startDate',
+	question: 'What is the start date?'
+	// ... other config
+};
+
+const endDateQuestion = {
+	type: COMPONENT_TYPES.DATE,
+	fieldName: 'endDate',
+	question: 'What is the end date?',
+	validators: [
+		new CrossQuestionValidator({
+			dependencyFieldName: 'startDate',
+			validationFunction: (endDate, startDate) => {
+				if (!endDate || !startDate) return true;
+				if (new Date(endDate) < new Date(startDate)) {
+					throw new Error('End date must be on or after the start date');
+				}
+				return true;
+			}
+		})
+	]
+};
+```
+
+**When to use:** Both questions are on separate pages and their answers are saved to the JourneyResponse before validation runs.
+
+### 2. Validation between regular questions (body data with formatting)
+
+When the current question's data needs to be extracted from `req.body` and formatted (e.g., date fields that come as separate day/month/year inputs), use `useBodyValuesForCurrent: true`.
+
+The validator will automatically use the question's `getDataToSave()` method to format the data correctly.
+
+```js
+const projectEndDateQuestion = {
+	type: COMPONENT_TYPES.DATE,
+	fieldName: 'projectEndDate',
+	question: 'When does the project end?',
+	validators: [
+		new CrossQuestionValidator({
+			dependencyFieldName: 'projectStartDate', // Already saved in JourneyResponse
+			useBodyValuesForCurrent: true, // Current answer from body, formatted via getDataToSave()
+			validationFunction: (endDate, startDate) => {
+				if (!endDate || !startDate) return true;
+				if (endDate < new Date(startDate)) {
+					throw new Error('Project end date must be on or after the project start date');
+				}
+				return true;
+			}
+		})
+	]
+};
+```
+
+**When to use:** The current question's answer is in `req.body` (not yet saved), but the dependency answer is already saved to the JourneyResponse. Works automatically with date questions, date-period questions, and other question types that have a `getDataToSave()` method.
+
+### 3. Validation between fields in a multi-field question (both from body)
+
+When validating between multiple fields on the same page (e.g., a `MultiFieldInputQuestion`), both current and reference values come from `req.body`. Use `useBodyValues: true`.
+
+```js
+const siteAreaQuestion = {
+	type: COMPONENT_TYPES.MULTI_FIELD_INPUT,
+	fieldName: 'siteArea',
+	question: 'What is the area of the site?',
+	inputFields: [
+		{ fieldName: 'siteAreaHectares', label: 'Site area in hectares (optional)' },
+		{ fieldName: 'siteAreaSquareMetres', label: 'Site area in square metres (optional)' }
+	],
+	validators: [
+		// Note: this is a custom validator not provided by default
+		new MultiFieldInputValidator({
+			fields: [
+				{
+					fieldName: 'siteAreaHectares',
+					validators: [
+						new CrossQuestionValidator({
+							dependencyFieldName: 'siteAreaSquareMetres',
+							useBodyValues: true,
+							validationFunction: (hectares, squareMetres) => {
+								if (hectares?.trim() && squareMetres?.trim()) {
+									throw new Error('Enter the site area in either hectares or square metres, not both');
+								}
+								return true;
+							}
+						})
+					]
+				}
+			]
+		})
+	]
+};
+```
+
+**When to use:** Multiple fields are on the same page and both values need to be read from `req.body` before either is saved.
+
+## How data sources are determined
+
+| `useBodyValues` | `useBodyValuesForCurrent` | Current Answer Source        | Dependency Answer Source |
+| --------------- | ------------------------- | ---------------------------- | ------------------------ |
+| `false`         | `false`                   | Session                      | Session                  |
+| `false`         | `true`                    | Body (via `getDataToSave()`) | Session                  |
+| `true`          | (ignored)                 | Body (via `getDataToSave()`) | Body (raw)               |
+
+## Notes
+
+- When `useBodyValuesForCurrent` is `true`, the validator uses the question's `getDataToSave()` method to format body data. This automatically handles complex field types like dates (`fieldName_day`, `fieldName_month`, `fieldName_year`).
+- The validator binds to the appropriate body field based on the question's `viewFolder` (e.g., `fieldName_day` for date questions).

--- a/src/validator/cross-question-validator.README.md
+++ b/src/validator/cross-question-validator.README.md
@@ -121,11 +121,11 @@ const siteAreaQuestion = {
 
 | `useBodyValues` | `useBodyValuesForCurrent` | Current Answer Source        | Dependency Answer Source |
 | --------------- | ------------------------- | ---------------------------- | ------------------------ |
-| `false`         | `false`                   | Session                      | Session                  |
-| `false`         | `true`                    | Body (via `getDataToSave()`) | Session                  |
+| `false`         | `false`                   | JourneyResponse              | JourneyResponse          |
+| `false`         | `true`                    | Body (via `getDataToSave()`) | JourneyResponse          |
 | `true`          | (ignored)                 | Body (via `getDataToSave()`) | Body (raw)               |
 
 ## Notes
 
 - When `useBodyValuesForCurrent` is `true`, the validator uses the question's `getDataToSave()` method to format body data. This automatically handles complex field types like dates (`fieldName_day`, `fieldName_month`, `fieldName_year`).
-- The validator binds to the appropriate body field based on the question's `viewFolder` (e.g., `fieldName_day` for date questions).
+- The validator binds to the appropriate body field using the question's `bodyFieldNames` getter. For simple questions this returns `[fieldName]`, but complex question types override it (e.g., `DateQuestion` returns `[fieldName_day, fieldName_month, fieldName_year]`). Custom question components can define their own `bodyFieldNames` getter to ensure proper validation binding.

--- a/src/validator/cross-question-validator.js
+++ b/src/validator/cross-question-validator.js
@@ -45,23 +45,17 @@ export class CrossQuestionValidator extends BaseValidator {
 	}
 
 	/**
-	 * Gets the body field name to bind validation to based on the question's view folder.
-	 * This determines which body field express-validator binds to for triggering validation.
+	 * Gets the body field name to bind validation to.
+	 * Uses the question's bodyFieldNames getter to determine which body field
+	 * express-validator binds to for triggering validation.
 	 * @param {import('../questions/question.js').Question} questionObj
 	 * @returns {string}
 	 */
 	#getBodyFieldName(questionObj) {
-		const fieldName = questionObj.fieldName;
-		const viewFolder = questionObj.viewFolder;
-
-		switch (viewFolder) {
-			case 'date':
-				return `${fieldName}_day`;
-			case 'date-period':
-				return `${fieldName}_start_day`;
-			default:
-				return fieldName;
-		}
+		// Use the first body field name from the question's bodyFieldNames getter
+		// This allows questions to define their own body field names, supporting
+		// custom components and complex field structures (e.g. date, date-time, address)
+		return questionObj.bodyFieldNames?.[0] ?? questionObj.fieldName;
 	}
 
 	/**

--- a/src/validator/cross-question-validator.js
+++ b/src/validator/cross-question-validator.js
@@ -11,16 +11,24 @@ export class CrossQuestionValidator extends BaseValidator {
 	validationFunction;
 	/** @type {boolean} */
 	useBodyValues;
+	/** @type {boolean} */
+	useBodyValuesForCurrent;
 
 	/**
 	 * @param {Object} params
 	 * @param {string} params.dependencyFieldName - The field name of the other question to compare against.
 	 * @param {((currentAnswer: unknown, dependencyAnswer: unknown) => boolean)| null} params.validationFunction - A function that takes the current question's answer and the other question's answer and returns true if valid, false otherwise.
-	 * @param {boolean} [params.useBodyValues=false] - Whether to use req.body values for validation (default: false). Usually CrossQuestionValidator will be for validating across saved session answers, but if used between multiple fields on one question, it will need to use the body.
+	 * @param {boolean} [params.useBodyValues=false] - Whether to use req.body values for validation (default: false). Usually CrossQuestionValidator will be for validating across saved JourneyResponse answers, but if used between multiple fields on one question, it will need to use the body.
+	 * @param {boolean} [params.useBodyValuesForCurrent=false] - Whether to use req.body values for the current question's answer (default: false). This may help with questions where data is not saved to the JourneyResponse on POST (e.g. non-multiple entities questions).
 	 * @throws {Error} If validationFunction is not provided or is not a function.
 	 * @throws {Error} If dependencyFieldName is not provided
 	 */
-	constructor({ dependencyFieldName, validationFunction, useBodyValues = false } = {}) {
+	constructor({
+		dependencyFieldName,
+		validationFunction,
+		useBodyValues = false,
+		useBodyValuesForCurrent = false
+	} = {}) {
 		super();
 
 		if (!dependencyFieldName) {
@@ -33,24 +41,65 @@ export class CrossQuestionValidator extends BaseValidator {
 		this.dependencyFieldName = dependencyFieldName;
 		this.validationFunction = validationFunction;
 		this.useBodyValues = useBodyValues;
+		this.useBodyValuesForCurrent = useBodyValues || useBodyValuesForCurrent;
+	}
+
+	/**
+	 * Gets the body field name to bind validation to based on the question's view folder.
+	 * This determines which body field express-validator binds to for triggering validation.
+	 * @param {import('../questions/question.js').Question} questionObj
+	 * @returns {string}
+	 */
+	#getBodyFieldName(questionObj) {
+		const fieldName = questionObj.fieldName;
+		const viewFolder = questionObj.viewFolder;
+
+		switch (viewFolder) {
+			case 'date':
+				return `${fieldName}_day`;
+			case 'date-period':
+				return `${fieldName}_start_day`;
+			default:
+				return fieldName;
+		}
 	}
 
 	/**
 	 * Validates response body against individual field validators.
+	 * Uses the question's getDataToSave method to extract and format body values when useBodyValuesForCurrent is true,
+	 * allowing generic handling of any question type without needing to know its internal structure.
 	 * @param {import('../questions/question.js').Question} questionObj - The question object containing the fieldName to validate.
 	 * @param {import('../journey/journey-response.js').JourneyResponse} [journeyResponse={}] - The current journey response, used to access saved answers for validation.
 	 * @returns {import('express-validator').ValidationChain[]}
 	 */
 	validate(questionObj, journeyResponse = {}) {
 		const fieldName = questionObj.fieldName;
+		const bodyFieldName = this.#getBodyFieldName(questionObj);
 
 		return [
-			body(fieldName).custom((value, { req }) => {
+			body(bodyFieldName).custom(async (value, { req }) => {
 				const answers = journeyResponse?.answers || {};
-				const currentAnswer = this.useBodyValues ? value : answers[fieldName];
+
+				let currentAnswer;
+				if (this.useBodyValuesForCurrent) {
+					// Use the question's own getDataToSave to format body data generically
+					if (typeof questionObj.getDataToSave === 'function') {
+						const { answers: formattedAnswers } = await questionObj.getDataToSave(req, journeyResponse);
+						// Use the formatted answer if available, otherwise return all formatted answers
+						// (handles MultiFieldInputQuestion which returns answers keyed by input field names)
+						currentAnswer = fieldName in formattedAnswers ? formattedAnswers[fieldName] : formattedAnswers;
+					} else {
+						// Fallback to raw body value if getDataToSave is not available
+						currentAnswer = req.body[fieldName];
+					}
+				} else {
+					currentAnswer = answers[fieldName];
+				}
+
 				const dependencyAnswer = this.useBodyValues
 					? req.body[this.dependencyFieldName]
 					: answers[this.dependencyFieldName];
+
 				return (
 					this.validationFunction(currentAnswer, dependencyAnswer) ||
 					// Fallback if validation fails without throwing an error

--- a/src/validator/cross-question-validator.test.js
+++ b/src/validator/cross-question-validator.test.js
@@ -17,13 +17,12 @@ function createMockRequest(answers) {
 /**
  * Creates a mock question object with a simple getDataToSave that returns the body field value.
  * @param {string} fieldName
- * @param {string} [viewFolder]
- * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ * @returns {{fieldName: string, bodyFieldNames: string[], getDataToSave: Function}}
  */
-function createMockQuestion(fieldName, viewFolder = 'default') {
+function createMockQuestion(fieldName) {
 	return {
 		fieldName,
-		viewFolder,
+		bodyFieldNames: [fieldName],
 		getDataToSave: async (req) => ({
 			answers: {
 				[fieldName]: req.body[fieldName]
@@ -35,12 +34,12 @@ function createMockQuestion(fieldName, viewFolder = 'default') {
 /**
  * Creates a mock date question that extracts date from day/month/year fields.
  * @param {string} fieldName
- * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ * @returns {{fieldName: string, bodyFieldNames: string[], getDataToSave: Function}}
  */
 function createMockDateQuestion(fieldName) {
 	return {
 		fieldName,
-		viewFolder: 'date',
+		bodyFieldNames: [`${fieldName}_day`, `${fieldName}_month`, `${fieldName}_year`],
 		getDataToSave: async (req) => {
 			const day = req.body[`${fieldName}_day`];
 			const month = req.body[`${fieldName}_month`];
@@ -60,12 +59,19 @@ function createMockDateQuestion(fieldName) {
 /**
  * Creates a mock date-period question that extracts start/end dates.
  * @param {string} fieldName
- * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ * @returns {{fieldName: string, bodyFieldNames: string[], getDataToSave: Function}}
  */
 function createMockDatePeriodQuestion(fieldName) {
 	return {
 		fieldName,
-		viewFolder: 'date-period',
+		bodyFieldNames: [
+			`${fieldName}_start_day`,
+			`${fieldName}_start_month`,
+			`${fieldName}_start_year`,
+			`${fieldName}_end_day`,
+			`${fieldName}_end_month`,
+			`${fieldName}_end_year`
+		],
 		getDataToSave: async (req) => {
 			const startDay = req.body[`${fieldName}_start_day`];
 			const startMonth = req.body[`${fieldName}_start_month`];
@@ -210,7 +216,7 @@ describe('CrossQuestionValidator', () => {
 		assert.deepEqual(validationFn.mock.calls[0].arguments, [undefined, undefined]);
 	});
 
-	describe('date question with viewFolder', () => {
+	describe('date question integration', () => {
 		it('should extract date using getDataToSave when useBodyValues is true', async () => {
 			const validationFn = mock.fn(() => true);
 			const validator = new CrossQuestionValidator({
@@ -276,7 +282,7 @@ describe('CrossQuestionValidator', () => {
 		});
 	});
 
-	describe('date-period question with viewFolder', () => {
+	describe('date-period question integration', () => {
 		it('should extract date period using getDataToSave when useBodyValues is true', async () => {
 			const validationFn = mock.fn(() => true);
 			const validator = new CrossQuestionValidator({
@@ -458,8 +464,7 @@ describe('CrossQuestionValidator', () => {
 			});
 			// Question without getDataToSave method
 			const questionObj = {
-				fieldName: 'field',
-				viewFolder: 'default'
+				fieldName: 'field'
 			};
 			const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
 			req.body = { field: 'from-body', other: 'from-body-dependency' };
@@ -482,7 +487,7 @@ describe('CrossQuestionValidator', () => {
 			// field names, not the question's fieldName
 			const questionObj = {
 				fieldName: 'contactDetails', // This won't be in formattedAnswers
-				viewFolder: 'multi-field-input',
+				bodyFieldNames: ['email', 'phone'],
 				getDataToSave: async (req) => ({
 					answers: {
 						// Returns individual input fields, not 'contactDetails'
@@ -508,6 +513,57 @@ describe('CrossQuestionValidator', () => {
 				phone: '123456789'
 			});
 			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
+	});
+
+	describe('bodyFieldNames getter support', () => {
+		it('should use bodyFieldNames[0] when question provides it', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn
+			});
+			// Mock question with custom bodyFieldNames getter
+			const questionObj = {
+				fieldName: 'customField',
+				bodyFieldNames: ['customField_first', 'customField_second'],
+				getDataToSave: async (req) => ({
+					answers: {
+						customField: req.body.customField_first + '-' + req.body.customField_second
+					}
+				})
+			};
+			const req = createMockRequest({ customField: 'stored-value', other: 'dep-value' });
+			req.body = {
+				customField_first: 'a',
+				customField_second: 'b',
+				other: 'body-dep'
+			};
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			// Should have called validation function with stored answer since useBodyValuesForCurrent is false
+			assert.deepEqual(validationFn.mock.calls[0].arguments, ['stored-value', 'dep-value']);
+		});
+
+		it('should fallback to fieldName when bodyFieldNames is not available', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn
+			});
+			// Question without bodyFieldNames getter
+			const questionObj = {
+				fieldName: 'simpleField'
+			};
+			const req = createMockRequest({ simpleField: 'stored-value', other: 'dep-value' });
+			req.body = {
+				simpleField: 'body-value'
+			};
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			assert.deepEqual(validationFn.mock.calls[0].arguments, ['stored-value', 'dep-value']);
 		});
 	});
 });

--- a/src/validator/cross-question-validator.test.js
+++ b/src/validator/cross-question-validator.test.js
@@ -14,6 +14,83 @@ function createMockRequest(answers) {
 	};
 }
 
+/**
+ * Creates a mock question object with a simple getDataToSave that returns the body field value.
+ * @param {string} fieldName
+ * @param {string} [viewFolder]
+ * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ */
+function createMockQuestion(fieldName, viewFolder = 'default') {
+	return {
+		fieldName,
+		viewFolder,
+		getDataToSave: async (req) => ({
+			answers: {
+				[fieldName]: req.body[fieldName]
+			}
+		})
+	};
+}
+
+/**
+ * Creates a mock date question that extracts date from day/month/year fields.
+ * @param {string} fieldName
+ * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ */
+function createMockDateQuestion(fieldName) {
+	return {
+		fieldName,
+		viewFolder: 'date',
+		getDataToSave: async (req) => {
+			const day = req.body[`${fieldName}_day`];
+			const month = req.body[`${fieldName}_month`];
+			const year = req.body[`${fieldName}_year`];
+			if (!day || !month || !year) {
+				throw new Error(`Incomplete date fields for ${fieldName}`);
+			}
+			return {
+				answers: {
+					[fieldName]: new Date(year, month - 1, day)
+				}
+			};
+		}
+	};
+}
+
+/**
+ * Creates a mock date-period question that extracts start/end dates.
+ * @param {string} fieldName
+ * @returns {{fieldName: string, viewFolder: string, getDataToSave: Function}}
+ */
+function createMockDatePeriodQuestion(fieldName) {
+	return {
+		fieldName,
+		viewFolder: 'date-period',
+		getDataToSave: async (req) => {
+			const startDay = req.body[`${fieldName}_start_day`];
+			const startMonth = req.body[`${fieldName}_start_month`];
+			const startYear = req.body[`${fieldName}_start_year`];
+			const endDay = req.body[`${fieldName}_end_day`];
+			const endMonth = req.body[`${fieldName}_end_month`];
+			const endYear = req.body[`${fieldName}_end_year`];
+			if (!startDay || !startMonth || !startYear) {
+				throw new Error(`Incomplete start date fields for ${fieldName}`);
+			}
+			if (!endDay || !endMonth || !endYear) {
+				throw new Error(`Incomplete end date fields for ${fieldName}`);
+			}
+			return {
+				answers: {
+					[fieldName]: {
+						start: new Date(startYear, startMonth - 1, startDay),
+						end: new Date(endYear, endMonth - 1, endDay)
+					}
+				}
+			};
+		}
+	};
+}
+
 describe('CrossQuestionValidator', () => {
 	test('should throw an error if dependencyFieldName is missing', () => {
 		assert.throws(() => {
@@ -39,7 +116,7 @@ describe('CrossQuestionValidator', () => {
 			dependencyFieldName: 'other',
 			validationFunction: validationFn
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const req = createMockRequest({ field: 'foo', other: 'bar' });
 		const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
 		await chain[0].run(req);
@@ -51,7 +128,7 @@ describe('CrossQuestionValidator', () => {
 			dependencyFieldName: 'other',
 			validationFunction: () => false
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const chain = validator.validate(questionObj);
 		const req = createMockRequest({ field: 'foo', other: 'bar' });
 		req.body = { field: 'foo' };
@@ -66,25 +143,28 @@ describe('CrossQuestionValidator', () => {
 			dependencyFieldName: 'other',
 			validationFunction: validationFn
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const chain = validator.validate(questionObj);
 		const req = { res: { locals: {} } };
 		await chain[0].run(req);
 		assert.deepEqual(validationFn.mock.calls[0].arguments, [undefined, undefined]);
 	});
 
-	it('should use session answers instead of request body values when useBodyValues is false', async () => {
+	it('should use JourneyResponse answers instead of request body values when useBodyValues is false', async () => {
 		const validationFn = mock.fn(() => true);
 		const validator = new CrossQuestionValidator({
 			dependencyFieldName: 'other',
 			validationFunction: validationFn
 		});
-		const questionObj = { fieldName: 'field' };
-		const req = createMockRequest({ field: 'from-session', other: 'from-session-dependency' });
+		const questionObj = createMockQuestion('field');
+		const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
 		req.body = { field: 'from-body', other: 'from-body-dependency' };
 		const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
 		await chain[0].run(req);
-		assert.deepEqual(validationFn.mock.calls[0].arguments, ['from-session', 'from-session-dependency']);
+		assert.deepEqual(validationFn.mock.calls[0].arguments, [
+			'from-journey-response',
+			'from-journey-response-dependency'
+		]);
 	});
 
 	it('should use request body values when useBodyValues is true', async () => {
@@ -94,9 +174,9 @@ describe('CrossQuestionValidator', () => {
 			useBodyValues: true,
 			validationFunction: validationFn
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const chain = validator.validate(questionObj);
-		const req = createMockRequest({ field: 'from-session', other: 'from-session-dependency' });
+		const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
 		req.body = { field: 'from-body', other: 'from-body-dependency' };
 		await chain[0].run(req);
 		assert.deepEqual(validationFn.mock.calls[0].arguments, ['from-body', 'from-body-dependency']);
@@ -109,7 +189,7 @@ describe('CrossQuestionValidator', () => {
 				throw new Error('boom');
 			}
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const chain = validator.validate(questionObj);
 		const req = createMockRequest({ field: 'foo', other: 'bar' });
 		const result = await chain[0].run(req);
@@ -123,10 +203,311 @@ describe('CrossQuestionValidator', () => {
 			dependencyFieldName: 'other',
 			validationFunction: validationFn
 		});
-		const questionObj = { fieldName: 'field' };
+		const questionObj = createMockQuestion('field');
 		const chain = validator.validate(questionObj);
 		const req = { res: { locals: { journeyResponse: {} } } };
 		await chain[0].run(req);
 		assert.deepEqual(validationFn.mock.calls[0].arguments, [undefined, undefined]);
+	});
+
+	describe('date question with viewFolder', () => {
+		it('should extract date using getDataToSave when useBodyValues is true', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValues: true
+			});
+			const questionObj = createMockDateQuestion('dateField');
+			const req = createMockRequest({});
+			req.body = {
+				dateField_day: '15',
+				dateField_month: '6',
+				dateField_year: '2026',
+				other: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.ok(currentAnswer instanceof Date, 'currentAnswer should be a Date');
+			assert.strictEqual(currentAnswer.getFullYear(), 2026);
+			assert.strictEqual(currentAnswer.getMonth() + 1, 6);
+			assert.strictEqual(currentAnswer.getDate(), 15);
+			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
+
+		it('should propagate error when getDataToSave throws (e.g. incomplete date fields)', async () => {
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true,
+				useBodyValues: true
+			});
+			const questionObj = createMockDateQuestion('dateField');
+			const req = createMockRequest({});
+			req.body = {
+				dateField_day: '15',
+				dateField_month: '6',
+				// missing year
+				other: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			const result = await chain[0].run(req);
+			assert.strictEqual(result.isEmpty(), false);
+			assert.match(result.array()[0].msg, /Incomplete date fields/);
+		});
+
+		it('should use JourneyResponse answer directly when useBodyValues is false', async () => {
+			const storedDate = new Date('2026-06-15T00:00:00.000Z');
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn
+			});
+			const questionObj = createMockDateQuestion('dateField');
+			const req = createMockRequest({ dateField: storedDate, other: 'dependency-value' });
+			req.body = { dateField_day: '15' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, storedDate);
+			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
+	});
+
+	describe('date-period question with viewFolder', () => {
+		it('should extract date period using getDataToSave when useBodyValues is true', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValues: true
+			});
+			const questionObj = createMockDatePeriodQuestion('periodField');
+			const req = createMockRequest({});
+			req.body = {
+				periodField_start_day: '1',
+				periodField_start_month: '6',
+				periodField_start_year: '2026',
+				periodField_end_day: '30',
+				periodField_end_month: '6',
+				periodField_end_year: '2026',
+				other: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.ok(currentAnswer.start instanceof Date, 'start should be a Date');
+			assert.ok(currentAnswer.end instanceof Date, 'end should be a Date');
+			assert.strictEqual(currentAnswer.start.getDate(), 1);
+			assert.strictEqual(currentAnswer.end.getDate(), 30);
+			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
+
+		it('should propagate error when getDataToSave throws for incomplete start date', async () => {
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true,
+				useBodyValues: true
+			});
+			const questionObj = createMockDatePeriodQuestion('periodField');
+			const req = createMockRequest({});
+			req.body = {
+				periodField_start_day: '1',
+				// missing start month and year
+				periodField_end_day: '30',
+				periodField_end_month: '6',
+				periodField_end_year: '2026',
+				other: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			const result = await chain[0].run(req);
+			assert.strictEqual(result.isEmpty(), false);
+			assert.match(result.array()[0].msg, /Incomplete start date fields/);
+		});
+
+		it('should propagate error when getDataToSave throws for incomplete end date', async () => {
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true,
+				useBodyValues: true
+			});
+			const questionObj = createMockDatePeriodQuestion('periodField');
+			const req = createMockRequest({});
+			req.body = {
+				periodField_start_day: '1',
+				periodField_start_month: '6',
+				periodField_start_year: '2026',
+				periodField_end_day: '30',
+				// missing end month and year
+				other: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			const result = await chain[0].run(req);
+			assert.strictEqual(result.isEmpty(), false);
+			assert.match(result.array()[0].msg, /Incomplete end date fields/);
+		});
+
+		it('should use JourneyResponse answer directly when useBodyValues is false', async () => {
+			const storedPeriod = {
+				start: new Date('2026-06-01T00:00:00.000Z'),
+				end: new Date('2026-06-30T00:00:00.000Z')
+			};
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn
+			});
+			const questionObj = createMockDatePeriodQuestion('periodField');
+			const req = createMockRequest({ periodField: storedPeriod, other: 'dependency-value' });
+			req.body = { periodField_start_day: '1' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, storedPeriod);
+			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
+	});
+
+	describe('useBodyValuesForCurrent', () => {
+		it('should set useBodyValuesForCurrent property correctly', () => {
+			const validator1 = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true,
+				useBodyValuesForCurrent: true
+			});
+			assert.strictEqual(validator1.useBodyValuesForCurrent, true);
+
+			const validator2 = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true,
+				useBodyValues: true
+			});
+			assert.strictEqual(validator2.useBodyValuesForCurrent, true);
+
+			const validator3 = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: () => true
+			});
+			assert.strictEqual(validator3.useBodyValuesForCurrent, false);
+		});
+
+		it('should use body value for current and JourneyResponse value for dependency when useBodyValuesForCurrent is true', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValuesForCurrent: true
+			});
+			const questionObj = createMockQuestion('field');
+			const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
+			req.body = { field: 'from-body', other: 'from-body-dependency' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, 'from-body');
+			assert.strictEqual(dependencyAnswer, 'from-journey-response-dependency');
+		});
+
+		it('should use body values for both current and dependency when useBodyValues is true', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValues: true
+			});
+			const questionObj = createMockQuestion('field');
+			const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
+			req.body = { field: 'from-body', other: 'from-body-dependency' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, 'from-body');
+			assert.strictEqual(dependencyAnswer, 'from-body-dependency');
+		});
+
+		it('should use JourneyResponse value for current when useBodyValuesForCurrent is false', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValuesForCurrent: false
+			});
+			const questionObj = createMockQuestion('field');
+			const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
+			req.body = { field: 'from-body', other: 'from-body-dependency' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, 'from-journey-response');
+			assert.strictEqual(dependencyAnswer, 'from-journey-response-dependency');
+		});
+
+		it('should fallback to req.body[fieldName] when getDataToSave is not available', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'other',
+				validationFunction: validationFn,
+				useBodyValuesForCurrent: true
+			});
+			// Question without getDataToSave method
+			const questionObj = {
+				fieldName: 'field',
+				viewFolder: 'default'
+			};
+			const req = createMockRequest({ field: 'from-journey-response', other: 'from-journey-response-dependency' });
+			req.body = { field: 'from-body', other: 'from-body-dependency' };
+			const chain = validator.validate(questionObj, req.res.locals.journeyResponse);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			assert.strictEqual(currentAnswer, 'from-body');
+			assert.strictEqual(dependencyAnswer, 'from-journey-response-dependency');
+		});
+
+		it('should return all formatted answers when fieldName is not in formattedAnswers', async () => {
+			const validationFn = mock.fn(() => true);
+			const validator = new CrossQuestionValidator({
+				dependencyFieldName: 'otherField',
+				validationFunction: validationFn,
+				useBodyValues: true
+			});
+			// Mock a behavior where getDataToSave returns answers keyed by input
+			// field names, not the question's fieldName
+			const questionObj = {
+				fieldName: 'contactDetails', // This won't be in formattedAnswers
+				viewFolder: 'multi-field-input',
+				getDataToSave: async (req) => ({
+					answers: {
+						// Returns individual input fields, not 'contactDetails'
+						email: req.body.email,
+						phone: req.body.phone
+					}
+				})
+			};
+			const req = createMockRequest({});
+			req.body = {
+				contactDetails: 'ignored',
+				email: 'test@example.com',
+				phone: '123456789',
+				otherField: 'dependency-value'
+			};
+			const chain = validator.validate(questionObj);
+			await chain[0].run(req);
+
+			const [currentAnswer, dependencyAnswer] = validationFn.mock.calls[0].arguments;
+			// Should receive all formatted answers since 'contactDetails' is not in formattedAnswers
+			assert.deepStrictEqual(currentAnswer, {
+				email: 'test@example.com',
+				phone: '123456789'
+			});
+			assert.strictEqual(dependencyAnswer, 'dependency-value');
+		});
 	});
 });


### PR DESCRIPTION
Up until now the CrossQuestionValidator has been used in two situations:
1. For manage list questions, where the reference question is already present in the session (i.e. answered in another question) and the current value has also been saved to the session (because it's manage list). `useBodyValues=false` (default).
2. For multi-field input questions, where neither current nor reference data has been saved to the session, but all is present in the `req.body`. `useBodyValues=true`.

However, for all other questions 1. the reference data exists in the session answers but 2. the current question data is only in `req.body` and is not formatted. This PR extends the validator to be able to work with any question by adding the `useBodyValuesForCurrent` param. It also utilises `questionObj.getDataToSave` so that calculated fields like dates etc. are passed as formatted data.

Finally, I've added a readme due to the complexity of the three different ways this validator can be used.

Although I'd prefer the `useBodyValuesForCurrent=true` behaviour to be the default, because this was originally built for manage list questions I've let `false` be the default so that it's not a breaking change.