### PR TITLE
fix(types): add classes param to InputField

### DIFF
--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -68,6 +68,7 @@ interface InputField {
 	suffix?: Affix; // used to add a suffix to the field
 	prefix?: Affix; // used to add a prefix to the field
 	hint?: string;
+	classes?: string;
 }
 
 /*


### PR DESCRIPTION
Get `InputField` structure in line with usage. All other params are already accounted for.