### PR TITLE
fix(types): clearly define all param types for each question

### DIFF
--- a/src/components/address/question.js
+++ b/src/components/address/question.js
@@ -7,7 +7,7 @@ import AddressValidator from '../../validator/address-validator.js';
 
 export class AddressQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
+	 * @param {import('../../questions/question-props.d.ts').SiteAddressQuestionParams} params
 	 */
 	constructor(params) {
 		super({

--- a/src/components/boolean/question.js
+++ b/src/components/boolean/question.js
@@ -33,20 +33,7 @@ export const booleanToYesNoOrNull = (value) => {
 
 export class BooleanQuestion extends RadioQuestion {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {string} [params.html]
-	 * @param {string} [params.interfaceType]
-	 * @param {Array.<import('../../questions/options-question.js').Option>} [params.options]
-	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
-	 * @param {boolean} [params.editable]
-	 * @param {import('#question-types').QuestionParameters['viewData']} [params.viewData]
+	 * @param {import('../../questions/question-props.d.ts').BooleanQuestionParams} params
 	 */
 	constructor({
 		title,

--- a/src/components/checkbox/question.js
+++ b/src/components/checkbox/question.js
@@ -12,16 +12,7 @@ const defaultOptionJoinString = ',';
 
 export class CheckboxQuestion extends OptionsQuestion {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.url]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {Array.<import('../../questions/options-question.js').Option>} params.options
-	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
-	 * @param {import('#question-types').QuestionParameters['viewData']} [params.viewData]
+	 * @param {import('../../questions/question-props.d.ts').CheckboxQuestionParams} params
 	 */
 	constructor({ title, question, fieldName, url, pageTitle, description, options, validators, viewData }) {
 		super({

--- a/src/components/date-period/question.js
+++ b/src/components/date-period/question.js
@@ -11,18 +11,20 @@ const DEFAULT_DATE_FORMAT = 'HH:mm d MMMM yyyy';
  */
 export class DatePeriodQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string} [params.dateFormat]
-	 * @param {{start: string, end: string}} [params.labels]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.hintStart]
-	 * @param {string} [params.hintEnd]
-	 * @param {{hour: number, minute: number, second: number}} [params.startTime]
-	 * @param {{hour: number, minute: number, second: number}} [params.endTime]
+	 * @param {import('../../questions/question-props.d.ts').DatePeriodQuestionParams} params
 	 */
-	constructor({ dateFormat = DEFAULT_DATE_FORMAT, hint, labels, hintStart, startTime, hintEnd, endTime, ...params }) {
+	constructor({
+		dateFormat = DEFAULT_DATE_FORMAT,
+		hint,
+		labels,
+		hintStart,
+		startTime,
+		hintEnd,
+		endTime,
+		...parentParams
+	}) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'date-period'
 		});
 		this.dateFormat = dateFormat;

--- a/src/components/date-time/question.js
+++ b/src/components/date-time/question.js
@@ -9,13 +9,11 @@ export class DateTimeQuestion extends Question {
 	static PM = 'pm';
 
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string} [params.dateFormat]
-	 * @param {string} [params.timeFormat]
+	 * @param {import('../../questions/question-props.d.ts').DateTimeQuestionParams} params
 	 */
-	constructor({ dateFormat = DEFAULT_DATE_FORMAT, timeFormat = DEFAULT_TIME_FORMAT, ...params }) {
+	constructor({ dateFormat = DEFAULT_DATE_FORMAT, timeFormat = DEFAULT_TIME_FORMAT, ...parentParams }) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'date-time'
 		});
 		this.dateFormat = dateFormat;

--- a/src/components/date/question.js
+++ b/src/components/date/question.js
@@ -8,12 +8,11 @@ const DEFAULT_DATE_FORMAT = 'd MMMM yyyy';
  */
 export class DateQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string} [params.dateFormat]
+	 * @param {import('../../questions/question-props.d.ts').DateQuestionParams} params
 	 */
-	constructor({ dateFormat = DEFAULT_DATE_FORMAT, ...params }) {
+	constructor({ dateFormat = DEFAULT_DATE_FORMAT, ...parentParams }) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'date'
 		});
 		this.dateFormat = dateFormat;

--- a/src/components/email/question.js
+++ b/src/components/email/question.js
@@ -15,11 +15,7 @@ import SingleLineInputQuestion from '../single-line-input/question.js';
  */
 export class EmailQuestion extends SingleLineInputQuestion {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input (will be merged with email defaults)
-	 * @param {string} [params.classes] html classes to add to the input
-	 * @param {string} [params.autocomplete] autocomplete attribute value (defaults to 'email')
+	 * @param {import('../../questions/question-props.d.ts').EmailQuestionParams} params
 	 */
 	constructor(params) {
 		// Set default input attributes for email

--- a/src/components/manage-list/question.js
+++ b/src/components/manage-list/question.js
@@ -19,7 +19,7 @@ export class ManageListQuestion extends Question {
 	#confirmationQuestionParam;
 
 	/**
-	 * @param {import('#question-types').QuestionParameters & ManageListQuestionParameters} params
+	 * @param {import('../../questions/question-props.d.ts').ManageListQuestionParams} params
 	 */
 	constructor(params) {
 		super({

--- a/src/components/multi-field-input/question.js
+++ b/src/components/multi-field-input/question.js
@@ -15,11 +15,11 @@ import { nl2br } from '../../lib/utils.js';
  */
 export class MultiFieldInputQuestion extends Question {
 	/**
-	 * @param {import('#src/questions/question-props.d.ts').MultiFieldInputQuestionProps} params
+	 * @param {import('../../questions/question-props.d.ts').MultiFieldInputQuestionParams} params
 	 */
-	constructor({ inputFields, ...params }) {
+	constructor({ inputFields, ...parentParams }) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'multi-field-input'
 		});
 

--- a/src/components/number-entry/question.js
+++ b/src/components/number-entry/question.js
@@ -3,13 +3,11 @@ import { getPersistedNumberAnswer } from '../utils/persisted-number-answer.js';
 
 export class NumberEntryQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string} [params.suffix]
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
+	 * @param {import('../../questions/question-props.d.ts').NumberEntryQuestionParams} params
 	 */
-	constructor({ label, suffix, ...params }) {
+	constructor({ label, suffix, ...parentParams }) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'number-entry'
 		});
 

--- a/src/components/radio/question.js
+++ b/src/components/radio/question.js
@@ -2,23 +2,7 @@ import OptionsQuestion from '../../questions/options-question.js';
 
 export class RadioQuestion extends OptionsQuestion {
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.viewFolder]
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {string} [params.label]
-	 * @param {string} [params.html]
-	 * @param {string} [params.legend] - optional legend, used instead of h1
-	 * @param {Array.<import('../../questions/options-question.js').Option>} params.options
-	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
-	 * @param {boolean} [params.editable]
-	 * @param {Object<string, any>} [params.viewData]
-	 * @param {import('#question-types').ActionLink} [params.actionLink]
+	 * @param {import('../../questions/question-props.d.ts').RadioQuestionParams} params
 	 */
 	constructor({
 		title,

--- a/src/components/select/question.js
+++ b/src/components/select/question.js
@@ -3,22 +3,7 @@ import OptionsQuestion from '../../questions/options-question.js';
 export class SelectQuestion extends OptionsQuestion {
 	#disableAccessibleAutocomplete;
 	/**
-	 * @param {Object} params
-	 * @param {string} params.title
-	 * @param {string} params.question
-	 * @param {string} params.fieldName
-	 * @param {string} [params.viewFolder]
-	 * @param {string} [params.url]
-	 * @param {string} [params.hint]
-	 * @param {string} [params.pageTitle]
-	 * @param {string} [params.description]
-	 * @param {string} [params.label]
-	 * @param {string} [params.html]
-	 * @param {string} [params.legend] - optional legend, used instead of h1
-	 * @param {string} [params.disableAccessibleAutocomplete]
-	 * @param {Array.<import('../../questions/options-question.js').Option>} params.options
-	 * @param {Object<string, any>} [params.viewData]
-	 * @param {Array.<import('#base-validator').BaseValidator>} [params.validators]
+	 * @param {import('../../questions/question-props.d.ts').SelectQuestionParams} params
 	 */
 	constructor({
 		title,

--- a/src/components/single-line-input/question.js
+++ b/src/components/single-line-input/question.js
@@ -8,10 +8,7 @@ export class SingleLineInputQuestion extends Question {
 	inputAttributes;
 
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {Record<string, string>} [params.inputAttributes] html attributes to add to the input
-	 * @param {string} [params.classes] html classes to add to the input
+	 * @param {import('../../questions/question-props.d.ts').SingleLineInputQuestionParams} params
 	 */
 	constructor(params) {
 		super({

--- a/src/components/text-entry-redact/question.js
+++ b/src/components/text-entry-redact/question.js
@@ -9,14 +9,7 @@ export const TRUNCATED_MAX_LENGTH = 500;
  */
 export class TextEntryRedactQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {import('../text-entry/question.js').TextEntryCheckbox} [params.textEntryCheckbox]
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
-	 * @param {boolean} [params.onlyShowRedactedValueForSummary] whether to only show redacted value for summary
-	 * @param {boolean} [params.useRedactedFieldNameForSave] whether to use the redacted field name when saving answers
-	 * @param {boolean} [params.showSuggestionsUi] use the suggestions UI for this question
-	 * @param {string} [params.summaryText] summaryText to use with the details component
-	 * @param {boolean} [params.shouldTruncateSummary] determines whether redacted comment is truncated in summary view
+	 * @param {import('../../questions/question-props.d.ts').TextEntryRedactQuestionParams} params
 	 */
 	constructor({
 		textEntryCheckbox,
@@ -26,10 +19,10 @@ export class TextEntryRedactQuestion extends Question {
 		showSuggestionsUi,
 		summaryText,
 		shouldTruncateSummary,
-		...params
+		...parentParams
 	}) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'text-entry-redact'
 		});
 

--- a/src/components/text-entry/question.js
+++ b/src/components/text-entry/question.js
@@ -19,13 +19,11 @@ import { Question } from '#question';
  */
 export class TextEntryQuestion extends Question {
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {TextEntryCheckbox} [params.textEntryCheckbox]
-	 * @param {string|undefined} [params.label] if defined this show as a label for the input and the question will just be a standard h1
+	 * @param {import('../../questions/question-props.d.ts').TextEntryQuestionParams} params
 	 */
-	constructor({ textEntryCheckbox, label, ...params }) {
+	constructor({ textEntryCheckbox, label, ...parentParams }) {
 		super({
-			...params,
+			...parentParams,
 			viewFolder: 'text-entry'
 		});
 

--- a/src/components/unit-option-entry/question.js
+++ b/src/components/unit-option-entry/question.js
@@ -35,16 +35,13 @@ export class UnitOptionEntryQuestion extends Question {
 	options;
 
 	/**
-	 * @param {import('#question-types').QuestionParameters} params
-	 * @param {string} [params.conditionalFieldName] // will be the quantity and is captured by the conditional in the options
-	 * @param {string} [params.label]
-	 * @param {Array.<UnitOption>} [params.options]
+	 * @param {import('../../questions/question-props.d.ts').UnitOptionEntryQuestionParams} params
 	 * @param {Record<string, Function>} [methodOverrides]
 	 */
-	constructor({ conditionalFieldName, options, label, ...params }, methodOverrides) {
+	constructor({ conditionalFieldName, options, label, ...parentParams }, methodOverrides) {
 		super(
 			{
-				...params,
+				...parentParams,
 				viewFolder: 'unit-option-entry'
 			},
 			methodOverrides

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -18,14 +18,22 @@ type QuestionTypes =
 	| 'text-entry-redact'
 	| 'unit-option';
 
-type CommonQuestionProps = Omit<QuestionParameters, 'viewFolder'> & {
+/**
+ * Base params that question classes need to function (NO type - that's routing metadata)
+ */
+export type CommonQuestionParams = Omit<QuestionParameters, 'viewFolder'>;
+
+/**
+ * Full props including type for routing/factory layer
+ */
+type CommonQuestionProps = CommonQuestionParams & {
 	type: QuestionTypes;
 };
 
 /**
  * Generic question props type so that custom components can be used without having to define a new type for each one.
  */
-export type BaseQuestionProps = Omit<CommonQuestionProps, 'type'> & {
+export type BaseQuestionProps = CommonQuestionParams & {
 	type: string;
 };
 
@@ -96,79 +104,174 @@ interface UnitOption {
 	};
 }
 
-type BooleanQuestionProps = CommonQuestionProps & {
-	type: 'boolean';
+/**
+ * Internal base params for questions with options - not exported
+ */
+type OptionsQuestionParams = CommonQuestionParams & {
+	options: Option[];
+};
+
+export type BooleanQuestionParams = Omit<RadioQuestionParams, 'options'> & {
 	options?: Option[];
 	interfaceType?: 'checkbox' | 'radio';
 };
 
-type CheckboxQuestionProps = CommonQuestionProps & {
-	type: 'checkbox';
-	options: Option[];
+type BooleanQuestionProps = BooleanQuestionParams & {
+	type: 'boolean';
 };
 
-type DateQuestionProps = CommonQuestionProps & {
+export type CheckboxQuestionParams = OptionsQuestionParams;
+
+type CheckboxQuestionProps = CheckboxQuestionParams & {
+	type: 'checkbox';
+};
+
+export type DateQuestionParams = CommonQuestionParams & {
+	dateFormat?: string;
+};
+
+type DateQuestionProps = DateQuestionParams & {
 	type: 'date';
 };
 
-type DatePeriodQuestionProps = CommonQuestionProps & {
+// Minute and second will default to 0 if not provided
+interface TimeComponents {
+	hour: number;
+	minute?: number;
+	second?: number;
+}
+
+export type DatePeriodQuestionParams = CommonQuestionParams & {
+	dateFormat?: string;
+	labels?: { start: string; end: string };
+	hintStart?: string;
+	hintEnd?: string;
+	startTime?: TimeComponents;
+	endTime?: TimeComponents;
+};
+
+type DatePeriodQuestionProps = DatePeriodQuestionParams & {
 	type: 'date-period';
 };
 
-type DateTimeQuestionProps = CommonQuestionProps & {
+export type DateTimeQuestionParams = CommonQuestionParams & {
+	dateFormat?: string;
+	timeFormat?: string;
+};
+
+type DateTimeQuestionProps = DateTimeQuestionParams & {
 	type: 'date-time';
 };
 
-type ManageListQuestionProps = CommonQuestionProps & {
+export type ManageListQuestionParams = CommonQuestionParams & {
+	titleSingular?: string;
+	showManageListQuestions?: boolean;
+	showAnswersInSummary?: boolean;
+	confirmationQuestion?: string;
+};
+
+type ManageListQuestionProps = ManageListQuestionParams & {
 	type: 'manage-list';
 };
 
-type EmailQuestionProps = CommonQuestionProps & {
+export type EmailQuestionParams = SingleLineInputQuestionParams & {
+	autocomplete?: string; // autocomplete attribute value (defaults to 'email')
+};
+
+type EmailQuestionProps = EmailQuestionParams & {
 	type: 'email';
 };
 
-export type MultiFieldInputQuestionProps = CommonQuestionProps & {
-	type: 'multi-field-input';
+export type MultiFieldInputQuestionParams = CommonQuestionParams & {
 	inputFields: InputField[];
 };
 
-type NumberEntryQuestionProps = CommonQuestionProps & {
-	type: 'number';
+export type MultiFieldInputQuestionProps = MultiFieldInputQuestionParams & {
+	type: 'multi-field-input';
+};
+
+export type NumberEntryQuestionParams = CommonQuestionParams & {
 	suffix?: string;
+	label?: string;
 };
 
-type RadioQuestionProps = CommonQuestionProps & {
+type NumberEntryQuestionProps = NumberEntryQuestionParams & {
+	type: 'number';
+};
+
+export type RadioQuestionParams = OptionsQuestionParams & {
+	label?: string;
+	legend?: string;
+};
+
+type RadioQuestionProps = RadioQuestionParams & {
 	type: 'radio';
-	options: Option[];
 };
 
-type SelectQuestionProps = CommonQuestionProps & {
-	type: 'select';
-	options: Option[];
+export type SelectQuestionParams = OptionsQuestionParams & {
 	disableAccessibleAutocomplete?: boolean;
+	label?: string;
+	legend?: string;
 };
 
-type SingleLineInputQuestionProps = CommonQuestionProps & {
+type SelectQuestionProps = SelectQuestionParams & {
+	type: 'select';
+};
+
+export type SingleLineInputQuestionParams = CommonQuestionParams & {
+	inputAttributes?: Record<string, string>; // HTML attributes to add to the input
+	label?: string; // if defined this will show as a label for the input and the question will just be a standard h1
+	classes?: string; // HTML classes to add to the input
+};
+
+type SingleLineInputQuestionProps = SingleLineInputQuestionParams & {
 	type: 'single-line-input';
-	inputAttributes?: Record<string, string>;
 };
 
-type SiteAddressQuestionProps = CommonQuestionProps & {
+export type SiteAddressQuestionParams = CommonQuestionParams;
+
+type SiteAddressQuestionProps = SiteAddressQuestionParams & {
 	type: 'site-address';
 };
 
-type TextEntryQuestionProps = CommonQuestionProps & {
+type TextEntryCheckbox = {
+	header: string;
+	text: string;
+	name: string;
+	errorMessage?: string;
+};
+
+export type TextEntryQuestionParams = CommonQuestionParams & {
+	textEntryCheckbox?: TextEntryCheckbox;
+	label?: string; // if defined this will show as a label for the input and the question will just be a standard h1
+};
+
+type TextEntryQuestionProps = TextEntryQuestionParams & {
 	type: 'text-entry';
 };
 
-type TextEntryRedactQuestionProps = CommonQuestionProps & {
+export type TextEntryRedactQuestionParams = CommonQuestionParams & {
+	textEntryCheckbox?: TextEntryCheckbox;
+	label?: string; // if defined this will show as a label for the input and the question will just be a standard h1
+	onlyShowRedactedValueForSummary?: boolean;
+	useRedactedFieldNameForSave?: boolean;
+	showSuggestionsUi?: boolean;
+	summaryText?: string; // summaryText to use with the details component
+	shouldTruncateSummary?: boolean; // determines whether redacted comment is truncated in summary view
+};
+
+type TextEntryRedactQuestionProps = TextEntryRedactQuestionParams & {
 	type: 'text-entry-redact';
 };
 
-type UnitOptionEntryQuestionProps = CommonQuestionProps & {
-	type: 'unit-option';
-	conditionalFieldName: string;
+export type UnitOptionEntryQuestionParams = CommonQuestionParams & {
+	conditionalFieldName: string; // will be the quantity and is captured by the conditional in the options
 	options: UnitOption[];
+	label?: string;
+};
+
+type UnitOptionEntryQuestionProps = UnitOptionEntryQuestionParams & {
+	type: 'unit-option';
 };
 
 export type QuestionProps =


### PR DESCRIPTION
Make sure that question parameter types are defined properly for each question.

- Use `question-props.d.ts` as the single source of truth, and import types from here to describe the params of each question in the JsDoc
- Introduce clear separation between `...Params` types (used for constructor parameters in question classes) and `...Props` types, which include the `type` parameter and are used for defining the objects of question properties. This is to fix a bug where custom questions extending dynamic-forms questions could not call `super(params)` because the `type` params did not match.
- Add missing parameters for `DatePeriodQuestionParams`, `DateTimeQuestionParams`, `ManageListQuestionParams`, `EmailQuestionParams`, `NumberEntryQuestionParams`, `RadioQuestionParams`, `SelectQuestionParams`, `SingleLineInputQuestionParams`, `TextEntryQuestionParams`, `TextEntryRedactQuestionParams` and `UnitOptionEntryQuestionParams`
- Introduce inheritance in the Param types to match the inheritance of the question classes
- Relabel spread params as `parentParams` to avoid conflict with JsDoc naming of `params`