### PR TITLE
fix: change validation error handling to await each validator sequentially

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -40,7 +40,11 @@ async function validateQuestion(questionObj, req, journeyResponse = {}) {
 		const validationRules = validation.validate(questionObj, journeyResponse);
 
 		if (validationRules instanceof Array) {
-			await Promise.all(validationRules.map((validator) => validator.run(req)));
+			// Intentionally run validators sequentially to ensure
+			// errors are collected in the same order as the rules array
+			for (const validator of validationRules) {
+				await validator.run(req);
+			}
 
 			const errors = validationResult(req);
 			const mappedErrors = errors.mapped();

--- a/src/validator/validator.test.js
+++ b/src/validator/validator.test.js
@@ -4,6 +4,7 @@ import validate from './validator.js';
 import RequiredValidator from './required-validator.js';
 import ValidOptionValidator from './valid-option-validator.js';
 import AddressValidator from './address-validator.js';
+import DateValidator from '#src/validator/date-validator.js';
 
 describe('./src/dynamic-forms/validator/validator.js', () => {
 	let mockRes;
@@ -240,6 +241,53 @@ describe('./src/dynamic-forms/validator/validator.js', () => {
 		assert.strictEqual(addressLine2._errors.length, 0);
 		assert.strictEqual(townCity._errors.length, 0);
 		assert.strictEqual(postcode._errors.length, 0);
+		assert.strictEqual(next.mock.callCount(), 1);
+	});
+
+	it('should display errors from a multi-field array validator in correct order (e.g., day, month, year)', async () => {
+		const req = {
+			params: {
+				section: 1,
+				question: 1,
+				referenceId: 'abc'
+			},
+			body: {
+				field1_day: '32',
+				field1_month: '13',
+				field1_year: '99'
+			}
+		};
+
+		mockRes.locals.journey = {
+			getQuestionByParams: function () {
+				return {
+					validators: [new DateValidator('the date')],
+					fieldName: 'field1'
+				};
+			}
+		};
+
+		const next = mock.fn();
+		await validate(req, mockRes, next);
+
+		const { validationResult } = await import('express-validator');
+		const errors = validationResult(req);
+		const mappedErrors = errors.mapped();
+		const errorKeys = Object.keys(mappedErrors);
+
+		// Verify all three errors exist
+		assert.strictEqual(errorKeys.includes('field1_day'), true, 'Missing day error');
+		assert.strictEqual(errorKeys.includes('field1_month'), true, 'Missing month error');
+		assert.strictEqual(errorKeys.includes('field1_year'), true, 'Missing year error');
+
+		// Verify errors are in the correct order: day, month, year
+		const dayIndex = errorKeys.indexOf('field1_day');
+		const monthIndex = errorKeys.indexOf('field1_month');
+		const yearIndex = errorKeys.indexOf('field1_year');
+
+		assert.strictEqual(dayIndex < monthIndex, true, 'Day error should come before month error');
+		assert.strictEqual(monthIndex < yearIndex, true, 'Month error should come before year error');
+
 		assert.strictEqual(next.mock.callCount(), 1);
 	});
 });


### PR DESCRIPTION
Describe

This pull request refactors the way validation rules are executed in the `validateQuestion` function. Instead of running all validators concurrently, they are now executed sequentially. This change can help prevent issues where validators depend on the results or side effects of previous validators.

**Validation execution changes:**

* Changed the execution of validation rules in `validateQuestion` from concurrent (`Promise.all`) to sequential (for-await loop), ensuring validators run one after another.


Ticket and screenshots
https://pins-ds.atlassian.net/browse/CROWN-138

Before changes 
<img width="1331" height="837" alt="image" src="https://github.com/user-attachments/assets/d5f74bc4-5196-4a67-b266-c65d683f6c7b" />


After changes
<img width="1301" height="824" alt="image" src="https://github.com/user-attachments/assets/dc64a8df-ba54-401c-9768-83483e77b243" />
