### PR TITLE
fix(multi-field-input): add inputmode and pattern params for input fields

### DIFF
--- a/src/components/multi-field-input/index.njk
+++ b/src/components/multi-field-input/index.njk
@@ -56,6 +56,8 @@
                                 text: inputField.hint
                             },
                             classes: inputField.classes or "govuk-input-!-width-three-quarters",
+                            inputmode: inputField.inputmode,
+                            pattern: inputField.pattern,
                             attributes: inputField.attributes
                         }) }}
                     {% endfor %}

--- a/src/questions/question-props.d.ts
+++ b/src/questions/question-props.d.ts
@@ -77,6 +77,8 @@ interface InputField {
 	prefix?: Affix; // used to add a prefix to the field
 	hint?: string;
 	classes?: string;
+	inputmode?: 'decimal' | 'numeric';
+	pattern?: string; // Used for backwards-compatibility for older iOS devices in numeric input fields
 }
 
 /*

--- a/test/questions.js
+++ b/test/questions.js
@@ -125,8 +125,8 @@ export const questionProps = {
 		url: 'companions',
 		label: 'Companions',
 		inputFields: [
-			{ fieldName: 'name', label: 'Name', type: COMPONENT_TYPES.TEXT_ENTRY },
-			{ fieldName: 'age', label: 'Age', type: COMPONENT_TYPES.NUMBER }
+			{ fieldName: 'name', label: 'Name' },
+			{ fieldName: 'age', label: 'Age', inputmode: 'numeric', pattern: '[0-9]*' }
 		]
 	},
 	nights: {

--- a/test/snapshots/companions.html
+++ b/test/snapshots/companions.html
@@ -22,7 +22,7 @@
   <label class="govuk-label govuk-label" for="age">
     Age
   </label>
-  <input class="govuk-input govuk-input-!-width-three-quarters" id="age" name="age" type="text">
+  <input class="govuk-input govuk-input-!-width-three-quarters" id="age" name="age" type="text" pattern="[0-9]*" inputmode="numeric">
 </div>
 
 

--- a/test/utils/question-test-utils.js
+++ b/test/utils/question-test-utils.js
@@ -81,6 +81,18 @@ export async function createAppWithQuestions(ctx, options) {
 }
 
 /**
+ * Returns a mock value for an input field based on its properties.
+ * @param {Object} field - An input field descriptor (not a full question)
+ * @returns {string|number}
+ */
+function mockInputFieldValue(field) {
+	if (field.inputmode === 'numeric' || field.pattern === '[0-9]*') {
+		return 1;
+	}
+	return 'test';
+}
+
+/**
  * Build a valid payload for a question.
  * @param {import('../src/questions/question-props.js').QuestionProps} q
  * @returns {Object}
@@ -128,7 +140,7 @@ export function mockAnswerBody(q) {
 		case COMPONENT_TYPES.MULTI_FIELD_INPUT: {
 			const res = {};
 			for (const field of q.inputFields) {
-				res[field.fieldName] = mockAnswer(field);
+				res[field.fieldName] = mockInputFieldValue(field);
 			}
 			return res;
 		}
@@ -191,7 +203,7 @@ export function mockAnswer(q) {
 			if (q.inputFields) {
 				let res = '';
 				for (const field of q.inputFields) {
-					res += mockAnswer(field) + '<br>';
+					res += mockInputFieldValue(field) + '<br>';
 				}
 				return res;
 			}


### PR DESCRIPTION
Whilst my long-term goal is to rebuild the multi-field input to allow `NumberEntryQuestion` as a child input, in the short term this fix is designed to support number entry fields in the multi-field input. There is [already attempted usage in the Crown project](https://github.com/Planning-Inspectorate/crown-developments/blob/868599c3c6bfd4e1756bb9f734fc09bf1ad4b3de/apps/manage/src/app/views/cases/view/question-utils.js#L97) but these params are not actually passed to the input component.