### PR TITLE
fix(manage-list): ManageListSection loses inherited Section methods

### DIFF
--- a/src/components/manage-list/manage-list-section.js
+++ b/src/components/manage-list/manage-list-section.js
@@ -1,4 +1,4 @@
-import { Section } from '#src/section.js';
+import { Section } from '../../section.js';
 
 /**
  * Extends the Section class for extra logic around managing lists.

--- a/src/section.js
+++ b/src/section.js
@@ -65,7 +65,7 @@ export class Section {
 	 * Add a condition to all questions in this section
 	 *
 	 * @param {QuestionCondition} shouldIncludeSection
-	 * @returns {Section}
+	 * @returns {this}
 	 */
 	withSectionCondition(shouldIncludeSection) {
 		if (this.questions.length > 0) {
@@ -134,7 +134,7 @@ export class Section {
 	/**
 	 * Fluent API method for attaching conditions to the previously added question
 	 * @param {QuestionCondition} shouldIncludeQuestion
-	 * @returns {Section}
+	 * @returns {this}
 	 */
 	withCondition(shouldIncludeQuestion) {
 		if (this.#conditionAdded) {
@@ -175,7 +175,7 @@ export class Section {
 	 * Fluent API method for starting a multi question condition
 	 * @param {string} conditionName
 	 * @param {QuestionCondition} shouldIncludeQuestion
-	 * @returns {Section}
+	 * @returns {this}
 	 */
 	startMultiQuestionCondition(conditionName, shouldIncludeQuestion) {
 		if (this.#multiQuestionConditions[conditionName]) {
@@ -188,7 +188,7 @@ export class Section {
 	/**
 	 * Fluent API method for ending a multi question condition
 	 * @param {string} conditionName
-	 * @returns {Section}
+	 * @returns {this}
 	 */
 	endMultiQuestionCondition(conditionName) {
 		if (!this.#multiQuestionConditions[conditionName]) {


### PR DESCRIPTION
In TS, `ManageListSection` doesn't inherit any of Section's methods, so `.withCondition()` errors even though it works at runtime.

- The generated `.d.ts` imports `Section` via `#src/section.js`, which consumers can't resolve
- The methods declare @returns {Section} instead of {this}, so chaining on a subclass narrows it to the base